### PR TITLE
Add persistent state tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                 </div>
                 <div class="choice-container">
                      <p>You've seen too much. The loop is no longer a question, but a certainty.</p>
-                     <button class="choice-btn" onclick="goToScene('scene-hallucination-start')">The vision triggers a shared spiral.</button>
+                     <button class="choice-btn" onclick="setState('awareOfLoop', true); goToScene('scene-hallucination-start')">The vision triggers a shared spiral.</button>
                 </div>
             </div>
 
@@ -186,7 +186,7 @@
                     <p>You're already in the loop. Panicking, you...</p>
                     <button class="choice-btn" onclick="goToScene('scene-smash-tv')">Smash the TV.</button>
                     <button class="choice-btn" onclick="goToScene('scene-run-away')">Get the hell out of the flat.</button>
-                     <button class="choice-btn" onclick="goToScene('scene-burn-tape')">Find the tape and burn it.</button>
+                     <button class="choice-btn" onclick="setState('hasTape', true); goToScene('scene-burn-tape')">Find the tape and burn it.</button>
                 </div>
             </div>
 
@@ -336,6 +336,7 @@
                  <div class="dialogue">
                      <span class="character system">SYSTEM:</span> The path forward is shrouded in smoke and static. The party awaits, and with it, a new set of choices that will either tighten the loop or shatter it entirely.
                 </div>
+                <div class="dialogue" id="state-summary"></div>
                 <h2 style="color: #ff00ff; text-align: center;">END OF EPISODE 1</h2>
                 <div class="choice-container">
                      <button class="choice-btn" onclick="restartGame()">RESTART THE LOOP</button>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,50 @@
     const recordLight = document.querySelector('.record-light');
     const episodeButtons = document.querySelectorAll('.episode-btn');
     
+
+// Persistent state
+const defaultState = { awareOfLoop: false, hasTape: false };
+let gameState = { ...defaultState };
+
+function loadState() {
+    const saved = localStorage.getItem("echoTapeState");
+    if (saved) {
+        try {
+            gameState = { ...defaultState, ...JSON.parse(saved) };
+        } catch (e) {
+            console.error("Failed to load state", e);
+        }
+    }
+}
+
+function saveState() {
+    localStorage.setItem("echoTapeState", JSON.stringify(gameState));
+}
+
+function setState(key, value) {
+    gameState[key] = value;
+    saveState();
+}
+
+function getState(key) {
+    return gameState[key];
+}
+
+function resetState() {
+    gameState = { ...defaultState };
+    saveState();
+}
+
+function updateStateSummary() {
+    const summary = document.getElementById("state-summary");
+    if (summary) {
+        const awareText = gameState.awareOfLoop ? "You know the loop is real." : "You remain unaware of the loop.";
+        const itemText = gameState.hasTape ? "The tape is in your possession." : "The tape is nowhere to be found.";
+        summary.textContent = awareText + " " + itemText;
+    }
+}
+
+loadState();
     startBtn.addEventListener('click', () => {
     titleScreen.style.display = 'none';
     episodeScreen.style.display = 'flex';
@@ -27,6 +71,7 @@
     // Hide the game container and return to episode selection
     gameContainer.style.display = 'none';
     recordLight.style.display = 'none';
+    resetState();
     episodeScreen.style.display = 'flex';
     }
     
@@ -37,5 +82,11 @@
     if (targetScene) {
     targetScene.style.display = 'block';
     targetScene.scrollIntoView({ behavior: 'smooth' });
+        if (sceneId === 'scene-tobecontinued') {
+            updateStateSummary();
+        }
     }
     }
+
+window.setState = setState;
+window.getState = getState;


### PR DESCRIPTION
## Summary
- track player decisions in `script.js`
- add persistent state messages in episode 1 scenes
- include summary of player choices at the end

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ac6e76500832a8694c9188301a02c