### PR TITLE
Add smooth transition animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - ARIA roles for interactive scenes.
 - Externalized CSS and JavaScript files (`style.css` and `script.js`).
 
+## [0.3.1] - 2025-06-24
+### Added
+- Smooth fade transitions when moving between screens and scenes.
+
 ## [0.2.0] - 2025-06-24
 ### Added
 - Episode selection screen that lets you choose which episode to play.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="title-screen" class="screen" style="display:flex;">
+    <div id="title-screen" class="screen visible">
          <h1 class="glitch-title">🌀 THE ECHO TAPE 🌀</h1>
          <p style="font-size: 1.2em; color: #ccc;">An Interactive Experience</p>
          <button id="start-btn" class="menu-btn">INSERT TAPE</button>
@@ -30,7 +30,7 @@
         
         <div class="vhs-screen">
             <!-- ########## START SCENE ########## -->
-            <div id="scene-start" class="interactive-scene" role="dialog" aria-label="scene-start">
+            <div id="scene-start" class="interactive-scene visible" role="dialog" aria-label="scene-start">
                 <h2 style="color: #ff00ff;">EPISODE 1: THE TAPE & THE LANE</h2>
                 <div class="dialogue">
                     <span class="character joe">JOE:</span> In the dusty catacombs of the Home Office, I found it. A VHS tape. Unlabelled, except for a yellowed Post-it screaming in quiet desperation: 'DO NOT WATCH ALONE.'

--- a/script.js
+++ b/script.js
@@ -50,43 +50,72 @@ function updateStateSummary() {
 }
 
 loadState();
-    startBtn.addEventListener('click', () => {
-    titleScreen.style.display = 'none';
-    episodeScreen.style.display = 'flex';
-    });
+
+function showScreen(el) {
+    el.style.display = 'flex';
+    requestAnimationFrame(() => el.classList.add('visible'));
+}
+
+function hideScreen(el) {
+    el.classList.remove('visible');
+    el.addEventListener('transitionend', function handler() {
+        el.style.display = 'none';
+        el.removeEventListener('transitionend', handler);
+    }, { once: true });
+}
+
+startBtn.addEventListener('click', () => {
+    hideScreen(titleScreen);
+    showScreen(episodeScreen);
+});
     
-    episodeButtons.forEach(btn => {
+episodeButtons.forEach(btn => {
     btn.addEventListener('click', () => {
-    const ep = btn.dataset.episode;
-    if (ep === '1') {
-        episodeScreen.style.display = 'none';
-        gameContainer.style.display = 'block';
-        recordLight.style.display = 'block';
-        goToScene('scene-start');
-    }
+        const ep = btn.dataset.episode;
+        if (ep === '1') {
+            hideScreen(episodeScreen);
+            gameContainer.style.display = 'block';
+            recordLight.style.display = 'block';
+            goToScene('scene-start');
+        }
     });
-    });
+});
     
-    function restartGame() {
-    // Hide the game container and return to episode selection
+function restartGame() {
     gameContainer.style.display = 'none';
     recordLight.style.display = 'none';
     resetState();
-    episodeScreen.style.display = 'flex';
-    }
+    showScreen(episodeScreen);
+}
     
-    function goToScene(sceneId) {
-    const scenes = document.querySelectorAll('.interactive-scene');
-    scenes.forEach(scene => scene.style.display = 'none');
+function showScene(scene) {
+    scene.style.display = 'block';
+    requestAnimationFrame(() => scene.classList.add('visible'));
+}
+
+function hideScene(scene) {
+    scene.classList.remove('visible');
+    scene.addEventListener('transitionend', function handler() {
+        scene.style.display = 'none';
+        scene.removeEventListener('transitionend', handler);
+    }, { once: true });
+}
+
+function goToScene(sceneId) {
     const targetScene = document.getElementById(sceneId);
-    if (targetScene) {
-    targetScene.style.display = 'block';
+    if (!targetScene) return;
+
+    const currentScene = document.querySelector('.interactive-scene.visible');
+    if (currentScene && currentScene !== targetScene) {
+        hideScene(currentScene);
+    }
+
+    showScene(targetScene);
     targetScene.scrollIntoView({ behavior: 'smooth' });
-        if (sceneId === 'scene-tobecontinued') {
-            updateStateSummary();
-        }
+    if (sceneId === 'scene-tobecontinued') {
+        updateStateSummary();
     }
-    }
+}
 
 window.setState = setState;
 window.getState = getState;

--- a/style.css
+++ b/style.css
@@ -30,6 +30,13 @@ body {
     align-items: center;
     text-align: center;
     z-index: 100;
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+.screen.visible {
+    display: flex;
+    opacity: 1;
 }
 
 #title-screen {
@@ -145,11 +152,18 @@ body {
     border-radius: 20px;
     margin: 30px 0;
     padding: 30px;
-    display: none; /* Initially hide all scenes */
+    display: none; /* Hidden until activated */
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+.interactive-scene.visible {
+    display: block;
+    opacity: 1;
 }
 
 #scene-start {
-    display: block; /* Show the starting scene by default */
+    display: block;
 }
 
 .character {


### PR DESCRIPTION
## Summary
- implement fade transitions for screens and scenes
- add helper functions in `script.js`
- mark starting elements with `visible` class
- document update in `CHANGELOG`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ac9906b98832ab8908aba874ba676