### PR TITLE
Slow overlay and memory flicker

### DIFF
--- a/style.css
+++ b/style.css
@@ -188,7 +188,7 @@ body {
     text-align: center;
     font-style: italic;
     color: #00ffff;
-    animation: flicker 1s infinite;
+    animation: flicker 2s infinite;
 }
 
 @keyframes flicker {
@@ -241,7 +241,7 @@ body {
 .static-overlay {
     position: fixed; top: 0; left: 0; width: 100%; height: 100%;
     background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><filter id="noiseFilter"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" stitchTiles="stitch"/></filter></defs><rect width="100%" height="100%" filter="url(%23noiseFilter)" opacity="0.05"/></svg>');
-    pointer-events: none; animation: static 0.1s infinite;
+    pointer-events: none; animation: static 0.3s infinite;
 }
 
 @keyframes static { 0% {opacity: 0.05;} 50% {opacity: 0.1;} 100% {opacity: 0.05;} }


### PR DESCRIPTION
## Summary
- slow the flicker effect
- slow the static overlay effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bc6b92d00832a88d2f7e84d428396