### PR TITLE
Enable keyboard navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@
     <div id="title-screen" class="screen visible">
          <h1 class="glitch-title">🌀 THE ECHO TAPE 🌀</h1>
          <p style="font-size: 1.2em; color: #ccc;">An Interactive Experience</p>
-         <button id="start-btn" class="menu-btn">INSERT TAPE</button>
+         <button id="start-btn" class="menu-btn" aria-label="Start the game">INSERT TAPE</button>
     </div>
 
     <div id="episode-screen" class="screen">
          <h1 class="glitch-title">SELECT EPISODE</h1>
-         <button class="episode-btn" data-episode="1">Episode 1: The Tape & The Lane</button>
-         <button class="episode-btn" disabled>Episode 2 - Coming Soon</button>
+         <button class="episode-btn" data-episode="1" aria-label="Play Episode 1">Episode 1: The Tape & The Lane</button>
+         <button class="episode-btn" disabled aria-label="Episode 2 coming soon">Episode 2 - Coming Soon</button>
     </div>
 
     <div class="static-overlay"></div>
@@ -28,8 +28,8 @@
     <div class="container">
         <h1 class="glitch-title">🌀 THE ECHO TAPE 🌀</h1>
         <div class="nav-controls">
-            <button id="back-btn" class="choice-btn" disabled>&larr; Back</button>
-            <button id="history-btn" class="choice-btn">History</button>
+            <button id="back-btn" class="choice-btn" disabled aria-label="Go back">&larr; Back</button>
+            <button id="history-btn" class="choice-btn" aria-label="View history">History</button>
         </div>
         
         <div class="vhs-screen">
@@ -354,7 +354,7 @@
             <h2 style="text-align:center;">Scene History</h2>
             <pre id="history-list"></pre>
             <div style="text-align:center; margin-top:10px;">
-                <button id="close-history-btn" class="choice-btn">Close</button>
+                <button id="close-history-btn" class="choice-btn" aria-label="Close history overlay">Close</button>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -167,6 +167,7 @@ async function goToScene(sceneId, fromBack = false) {
     playSceneSound();
     updateBackButton();
     targetScene.scrollIntoView({ behavior: 'smooth' });
+    focusFirstChoice(targetScene);
     if (sceneId === 'scene-tobecontinued') {
         updateStateSummary();
     }
@@ -203,3 +204,40 @@ if (historyBtn) historyBtn.addEventListener('click', showHistory);
 if (closeHistoryBtn) closeHistoryBtn.addEventListener('click', closeHistory);
 
 updateBackButton();
+
+function focusFirstChoice(scene) {
+    const first = scene.querySelector('.choice-btn');
+    if (first) {
+        first.focus();
+    }
+}
+
+function handleKeydown(event) {
+    if (historyOverlay && historyOverlay.classList.contains('visible')) return;
+
+    const currentScene = document.querySelector('.interactive-scene.visible');
+    if (!currentScene) return;
+
+    const choices = Array.from(currentScene.querySelectorAll('.choice-btn'));
+    if (choices.length === 0) return;
+
+    let index = choices.indexOf(document.activeElement);
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+        index = (index + 1) % choices.length;
+        choices[index].focus();
+        event.preventDefault();
+    } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+        index = (index - 1 + choices.length) % choices.length;
+        choices[index].focus();
+        event.preventDefault();
+    } else if (/^[1-9]$/.test(event.key)) {
+        const num = parseInt(event.key, 10) - 1;
+        if (num >= 0 && num < choices.length) {
+            choices[num].focus();
+            choices[num].click();
+        }
+    }
+}
+
+document.addEventListener('keydown', handleKeydown);


### PR DESCRIPTION
## Summary
- add aria labels for menus
- focus first choice button when a scene loads
- implement keydown handler to navigate choices via arrows or 1-9 keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bcef54d44832aa47b22f110e3e8db