### PR TITLE
Reset version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.3] - 2025-06-28
+## [0.1] - 2025-06-25
+### Changed
+- Renumbered previous releases under the 0.0.x scheme.
+
+## [0.0.4.3] - 2025-06-28
 ### Added
 - Tip on using built-in CSS classes in the writing guide.
 ### Changed
 - README now explains how to run the test script.
 
-## [0.3.0] - 2025-06-24
+## [0.0.3.0] - 2025-06-24
 ### Added
 - SEO meta description and Open Graph tags.
 - ARIA roles for interactive scenes.
 - Externalized CSS and JavaScript files (`style.css` and `script.js`).
 
-## [0.3.1] - 2025-06-24
+## [0.0.3.1] - 2025-06-24
 ### Added
 - Smooth fade transitions when moving between screens and scenes.
 
-## [0.4.0] - 2025-06-25
+## [0.0.4.0] - 2025-06-25
 ### Added
 - Basic sound effects when navigating scenes.
 - Scene navigation history overlay.
@@ -29,7 +33,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Minor bugs discovered during playtesting.
 
-## [0.4.1] - 2025-06-26
+## [0.0.4.1] - 2025-06-26
 ### Added
 - Embedded episode data so the game works when opened directly from the file system.
 ### Changed
@@ -37,14 +41,14 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Episode selection now loads correctly without a web server.
 
-## [0.4.2] - 2025-06-27
+## [0.0.4.2] - 2025-06-27
 ### Added
 - Mute controls for background static and button click sounds.
 - Global click sound plays when any button is pressed.
 ### Changed
 - Static and click audio now respect the mute settings.
 
-## [0.2.0] - 2025-06-24
+## [0.0.2.0] - 2025-06-24
 ### Added
 - Episode selection screen that lets you choose which episode to play.
 


### PR DESCRIPTION
## Summary
- set new top version 0.1 in CHANGELOG
- renumber earlier releases under 0.0.x scheme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bdd91c41c832aa756b51c42cdf84e