### PR TITLE
Add persistent episode progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.1] - 2025-06-30
+### Added
+- Save progress across sessions with a Continue option.
+### Changed
+- Restarting the game now clears saved progress.
+
 
 ## [0.1] - 2025-06-25
 ### Changed

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
          <h1 class="glitch-title">🌀 THE ECHO TAPE 🌀</h1>
          <p style="font-size: 1.2em; color: #ccc;">An Interactive Experience</p>
          <button id="start-btn" class="menu-btn" aria-label="Start the game">INSERT TAPE</button>
+        <button id="continue-btn" class="menu-btn" style="display:none" aria-label="Continue game">CONTINUE</button>
     </div>
 
     <div id="episode-screen" class="screen">


### PR DESCRIPTION
## Summary
- add Continue button to resume progress
- persist episode and scene progress in `localStorage`
- clear saved progress when restarting game
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c136310c0832a9e88ac74b63764ef