### PR TITLE
Fix broken Insert Tape button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.3] - 2025-07-02
+### Fixed
+- Missing `continueBtn` definition prevented the "Insert Tape" button from working.
 ## [0.1.2] - 2025-07-01
 ### Added
 - Noted early development status in README and AGENTS.

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@
     const skipIntroBtn = document.getElementById('skip-intro-btn');
     const gameContainer = document.querySelector('.container');
     const startBtn = document.getElementById('start-btn');
+    const continueBtn = document.getElementById('continue-btn');
     const recordLight = document.querySelector('.record-light');
     const episodeButtons = document.querySelectorAll('.episode-btn');
     const backBtn = document.getElementById('back-btn');


### PR DESCRIPTION
## Summary
- define `continueBtn` constant in `script.js`
- document fix in `CHANGELOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1acfd034832a975c70bb790aff80