### PR TITLE
Stop static audio when leaving episode

### DIFF
--- a/script.js
+++ b/script.js
@@ -218,6 +218,9 @@ if (returnTitleBtn) {
     returnTitleBtn.addEventListener('click', () => {
         hideScreen(episodeScreen);
         showScreen(titleScreen);
+        if (sfxStatic) {
+            sfxStatic.pause();
+        }
     });
 }
 if (continueBtn) {
@@ -271,6 +274,9 @@ episodeButtons.forEach(btn => {
 function restartGame() {
     gameContainer.style.display = 'none';
     recordLight.style.display = 'none';
+    if (sfxStatic) {
+        sfxStatic.pause();
+    }
     currentEpisode = null;
     selectedEpisode = null;
     introTimers.forEach(clearTimeout);


### PR DESCRIPTION
## Summary
- stop the looping static audio when leaving the episode screen
- stop static audio when restarting the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c215b34e0832a8707552a2fb23542