### PR TITLE
Add fade-in effect for title music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.9] - 2025-07-08
+### Added
+- Volume sliders for music and SFX with adjustable levels.
+- Title music continues on the episode selection screen.
+### Changed
+- Audio helper functions respect the current volume settings.
 ## [0.1.8] - 2025-07-07
 ### Added
 - Title music now fades in over three seconds after a short delay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.8] - 2025-07-07
+### Added
+- Title music now fades in over three seconds after a short delay.
+### Changed
+- `playTitleMusic` logic updated to support volume fade.
 ## [0.1.7] - 2025-07-06
 ### Added
 - Background title music now plays on the start screen.

--- a/index.html
+++ b/index.html
@@ -56,7 +56,11 @@
         </div>
         <div class="audio-controls">
             <button id="mute-music-btn" class="choice-btn" aria-label="Toggle static audio">Mute Music</button>
+            <label for="music-volume" class="visually-hidden">Music Volume</label>
+            <input type="range" id="music-volume" min="0" max="1" step="0.01" value="1" aria-label="Music volume">
             <button id="mute-sfx-btn" class="choice-btn" aria-label="Toggle click sound">Mute SFX</button>
+            <label for="sfx-volume" class="visually-hidden">SFX Volume</label>
+            <input type="range" id="sfx-volume" min="0" max="1" step="0.01" value="1" aria-label="SFX volume">
         </div>
         <div id="vhs-screen" class="vhs-screen"></div>
         

--- a/script.js
+++ b/script.js
@@ -152,15 +152,37 @@ function playClickSound() {
     }
 }
 
-function playTitleMusic() {
-    if (titleMusic && titleMusic.paused && !musicMuted) {
-        titleMusic.currentTime = 0;
-        const playPromise = titleMusic.play();
-        if (playPromise && typeof playPromise.catch === 'function') {
-            playPromise.catch(() => {
-                document.addEventListener('click', () => titleMusic.play(), { once: true });
-            });
+function fadeInAudio(el, duration) {
+    if (!el) return;
+    const start = performance.now();
+    el.volume = 0;
+    function step(now) {
+        const progress = Math.min((now - start) / duration, 1);
+        let volume;
+        if (progress < 0.5) {
+            volume = progress * 1.2; // 60% volume halfway
+        } else {
+            volume = 0.6 + (progress - 0.5) * 0.8;
         }
+        el.volume = Math.min(volume, 1);
+        if (progress < 1) requestAnimationFrame(step);
+    }
+    requestAnimationFrame(step);
+}
+
+function playTitleMusic() {
+    if (titleMusic && !musicMuted) {
+        const startPlayback = () => {
+            titleMusic.currentTime = 0;
+            const playPromise = titleMusic.play();
+            if (playPromise && typeof playPromise.catch === 'function') {
+                playPromise.catch(() => {
+                    document.addEventListener('click', () => titleMusic.play(), { once: true });
+                });
+            }
+            fadeInAudio(titleMusic, 3000);
+        };
+        setTimeout(startPlayback, 500);
     }
 }
 

--- a/script.js
+++ b/script.js
@@ -22,6 +22,8 @@
     const closeHistoryBtn = document.getElementById('close-history-btn');
     const muteMusicBtn = document.getElementById('mute-music-btn');
     const muteSfxBtn = document.getElementById('mute-sfx-btn');
+    const musicVolSlider = document.getElementById('music-volume');
+    const sfxVolSlider = document.getElementById('sfx-volume');
     const sfxClick = document.getElementById('sfx-click');
     const sfxStatic = document.getElementById('sfx-static');
     const titleMusic = document.getElementById('title-music');
@@ -38,6 +40,8 @@ let audioCtx;
 // Audio settings
 let musicMuted = false;
 let sfxMuted = false;
+let musicVolume = 1;
+let sfxVolume = 1;
 
 // Tracks the sequence of visited scenes
 let sceneHistory = [];
@@ -133,6 +137,7 @@ function initAudio() {
 
 function playVhsSound() {
     if (sfxStatic && sfxStatic.paused && !musicMuted) {
+        sfxStatic.volume = musicVolume;
         sfxStatic.currentTime = 0;
         sfxStatic.play();
     }
@@ -140,6 +145,7 @@ function playVhsSound() {
 
 function playSceneSound() {
     if (sfxStatic && sfxStatic.paused && !musicMuted) {
+        sfxStatic.volume = musicVolume;
         sfxStatic.currentTime = 0;
         sfxStatic.play();
     }
@@ -147,12 +153,13 @@ function playSceneSound() {
 
 function playClickSound() {
     if (sfxClick && !sfxMuted) {
+        sfxClick.volume = sfxVolume;
         sfxClick.currentTime = 0;
         sfxClick.play();
     }
 }
 
-function fadeInAudio(el, duration) {
+function fadeInAudio(el, duration, targetVol = 1) {
     if (!el) return;
     const start = performance.now();
     el.volume = 0;
@@ -164,7 +171,7 @@ function fadeInAudio(el, duration) {
         } else {
             volume = 0.6 + (progress - 0.5) * 0.8;
         }
-        el.volume = Math.min(volume, 1);
+        el.volume = Math.min(volume, 1) * targetVol;
         if (progress < 1) requestAnimationFrame(step);
     }
     requestAnimationFrame(step);
@@ -180,7 +187,7 @@ function playTitleMusic() {
                     document.addEventListener('click', () => titleMusic.play(), { once: true });
                 });
             }
-            fadeInAudio(titleMusic, 3000);
+            fadeInAudio(titleMusic, 3000, musicVolume);
         };
         setTimeout(startPlayback, 500);
     }
@@ -293,7 +300,6 @@ function hideScreen(el) {
 
 startBtn.addEventListener('click', () => {
     initAudio();
-    stopTitleMusic();
     hideScreen(titleScreen);
     showScreen(episodeScreen);
 });
@@ -339,6 +345,7 @@ if (clearSaveBtn) {
 }
 
 function startEpisode(ep) {
+    stopTitleMusic();
     hideScreen(introScreen);
     gameContainer.style.display = 'block';
     currentEpisode = ep;
@@ -390,6 +397,7 @@ function restartGame() {
     if (screen) screen.innerHTML = '';
     updateBackButton();
     showScreen(episodeScreen);
+    playTitleMusic();
 }
     
 function showScene(scene) {
@@ -474,6 +482,21 @@ if (muteSfxBtn) {
         sfxMuted = !sfxMuted;
         if (sfxClick) sfxClick.muted = sfxMuted;
         muteSfxBtn.textContent = sfxMuted ? 'Unmute SFX' : 'Mute SFX';
+    });
+}
+
+if (musicVolSlider) {
+    musicVolSlider.addEventListener('input', () => {
+        musicVolume = parseFloat(musicVolSlider.value);
+        if (titleMusic) titleMusic.volume = musicVolume;
+        if (sfxStatic) sfxStatic.volume = musicVolume;
+    });
+}
+
+if (sfxVolSlider) {
+    sfxVolSlider.addEventListener('input', () => {
+        sfxVolume = parseFloat(sfxVolSlider.value);
+        if (sfxClick) sfxClick.volume = sfxVolume;
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -329,3 +329,15 @@ body {
     margin: 0 5px;
     padding: 5px 10px;
 }
+.audio-controls input[type=range] {
+    margin: 0 5px;
+    vertical-align: middle;
+}
+
+.visually-hidden {
+    position: absolute !important;
+    height: 1px; width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+}


### PR DESCRIPTION
## Summary
- fade in title music when the page loads
- document the new behavior in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2af670dc832a830f2b777adcb802