### PR TITLE
Add episode file validation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.13] - 2025-07-12
+### Added
+- Test now validates episode JSON files and their generated JS counterparts.
 ## [0.1.12] - 2025-07-11
 ### Added
 - Script `tools/embedEpisodes.js` to embed JSON episodes into JavaScript.

--- a/test/check.js
+++ b/test/check.js
@@ -1,5 +1,6 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
+const path = require('path');
 
 const requiredFiles = ['index.html', 'script.js', 'style.css'];
 let missing = false;
@@ -14,6 +15,32 @@ try {
 } catch (err) {
   console.error('Syntax error in script.js');
   missing = true;
+}
+
+// Verify each episode JSON and its generated JS file
+const episodesDir = path.join(__dirname, '..', 'episodes');
+const episodeJsons = fs.readdirSync(episodesDir).filter(f => f.endsWith('.json'));
+for (const jsonFile of episodeJsons) {
+  const jsonPath = path.join(episodesDir, jsonFile);
+  try {
+    JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  } catch (err) {
+    console.error(`Invalid JSON in ${jsonFile}: ${err.message}`);
+    missing = true;
+  }
+
+  const jsPath = path.join(episodesDir, jsonFile.replace(/\.json$/, '.js'));
+  if (!fs.existsSync(jsPath)) {
+    console.error(`Missing generated JS for ${jsonFile}`);
+    missing = true;
+  } else {
+    try {
+      execSync(`node -c "${jsPath}"`, { stdio: 'inherit' });
+    } catch (err) {
+      console.error(`Syntax error in ${jsPath}`);
+      missing = true;
+    }
+  }
 }
 if (missing) {
   console.error('Test failed');


### PR DESCRIPTION
## Summary
- extend `test/check.js` to parse each episode JSON and ensure its JS file exists
- create a 0.1.13 changelog entry documenting the new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c7ad57e24832a8fa0875456224765