### PR TITLE
Add episode build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.14] - 2025-07-13
+### Added
+- Build script `scripts/embedEpisodes.js` for embedding episodes.
+
 ## [0.1.13] - 2025-07-12
 ### Added
 - Test now validates episode JSON files and their generated JS counterparts.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "script.js",
   "scripts": {
     "test": "node test/check.js",
-    "embed": "node tools/embedEpisodes.js"
+    "embed": "node tools/embedEpisodes.js",
+    "build-episodes": "node scripts/embedEpisodes.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/embedEpisodes.js
+++ b/scripts/embedEpisodes.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const episodesDir = path.join(__dirname, '..', 'episodes');
+
+const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.json'));
+
+files.forEach(file => {
+  const jsonPath = path.join(episodesDir, file);
+  const jsonData = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  const name = path.basename(file, '.json');
+  const jsPath = path.join(episodesDir, `${name}.js`);
+  const jsContent =
+    'window.localEpisodes = window.localEpisodes || {};' +
+    `\nwindow.localEpisodes[${JSON.stringify(name)}] = ` +
+    JSON.stringify(jsonData, null, 2) + ';\n';
+  fs.writeFileSync(jsPath, jsContent);
+});
+
+console.log('Embedded', files.length, 'episodes');


### PR DESCRIPTION
## Summary
- add `scripts/embedEpisodes.js` to embed episodes
- add `build-episodes` npm script
- document new script in CHANGELOG

## Testing
- `npm run build-episodes`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c7eeb5278832a9141d4bb2d5e7746