### PR TITLE
Handle localStorage errors gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.17] - 2025-07-16
+### Fixed
+- Gracefully handle failures when accessing `localStorage` by falling back to in-memory state.
 ## [0.1.16] - 2025-07-15
 ### Changed
 - Updated HTML title and Open Graph title to remove episode number.


### PR DESCRIPTION
## Summary
- prevent crashes when localStorage is unavailable
- detect localStorage errors for game state and progress
- log a warning and fallback to in-memory storage
- document change in CHANGELOG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c8587b760832a8f8986dd851dfab2