### PR TITLE
Add home button on first scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.24] - 2025-07-23
+### Added
+- "Home" button on the first scene of each episode now returns to the title screen.
+
 ## [0.1.23] - 2025-07-22
 ### Added
 - Runtime tests for state persistence and audio controls.


### PR DESCRIPTION
## Summary
- enable a home button when at the first scene
- new handler returns players to the title screen from the first scene
- document the change in `CHANGELOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c952da594832abdbf6888f76a04ff