### PR TITLE
Use incremental changelog numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,175 +2,80 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.26] - 2025-07-25
+## [0.0.0.5] - 2025-07-25
 ### Changed
 - Updated README and writing guide with instructions on building episodes and running tests.
 
-## [0.1.25] - 2025-07-24
+## [0.0.0.4] - 2025-07-24
 ### Added
 - Centralized image assets in new `images/` folder.
-
-## [0.1.24] - 2025-07-23
-### Added
 - "Home" button on the first scene of each episode now returns to the title screen.
-
-## [0.1.23] - 2025-07-22
-### Added
 - Runtime tests for state persistence and audio controls.
 
-## [0.1.22] - 2025-07-21
-### Changed
+## [0.0.0.3] - 2025-07-21
+### Added
 - Replaced inline `onclick` attributes in episode files with `data` attributes and event delegation.
 - Updated writing guide and tests accordingly.
-
-## [0.1.21] - 2025-07-20
-### Changed
 - Split `script.js` into `state.js`, `audio.js`, and `ui.js` modules.
-
-## [0.1.20] - 2025-07-19
-### Added
 - Audio mute and volume preferences are now saved in persistent game state.
-
-## [0.1.19] - 2025-07-18
-### Added
 - Test now checks for duplicate scene IDs and broken `goToScene` links.
-
-## [0.1.18] - 2025-07-17
-### Changed
 - Consolidated episode embedding scripts into `scripts/embedEpisodes.js`.
 - `npm run embed` now runs the same script as `npm run build-episodes`.
-## [0.1.17] - 2025-07-16
-### Changed
 - Gracefully handle missing `localStorage` when loading or saving state.
-
-## [0.1.16] - 2025-07-15
-### Changed
 - Updated HTML title and Open Graph title to remove episode number.
-
-## [0.1.15] - 2025-07-14
-### Changed
 - Contributor guide now instructs running `npm run build-episodes` after editing episodes and committing the generated files.
-## [0.1.14] - 2025-07-13
-### Added
 - Build script `scripts/embedEpisodes.js` for embedding episodes.
-
-## [0.1.13] - 2025-07-12
-### Added
 - Test now validates episode JSON files and their generated JS counterparts.
-## [0.1.12] - 2025-07-11
-### Added
 - Script `tools/embedEpisodes.js` to embed JSON episodes into JavaScript.
-### Changed
 - Contributor guide now notes running `npm run embed` after editing episodes.
 
-## [0.1.11] - 2025-07-10
-### Changed
+## [0.0.0.2] - 2025-07-10
+### Added
 - Audio files now use .ogg format and .wav files removed.
 - Static audio stops when returning to menus.
-
-## [0.1.10] - 2025-07-09
-### Added
 - Second title music track that plays on the episode selection screen.
-### Changed
 - Title music begins immediately on the title screen.
-## [0.1.9] - 2025-07-08
-### Added
 - Volume sliders for music and SFX with adjustable levels.
 - Title music continues on the episode selection screen.
-### Changed
 - Audio helper functions respect the current volume settings.
-## [0.1.8] - 2025-07-07
-### Added
 - Title music now fades in over three seconds after a short delay.
-### Changed
 - `playTitleMusic` logic updated to support volume fade.
-## [0.1.7] - 2025-07-06
-### Added
 - Background title music now plays on the start screen.
-### Changed
 - `titleMusic.wav` moved into the `audio` folder.
-## [0.1.6] - 2025-07-05
-### Added
 - Simple dev tools screen with a button to clear saved progress.
-### Fixed
 - Continue now resumes play immediately instead of showing the episode menu.
-## [0.1.5] - 2025-07-04
-### Added
 - Conditional `showIf` support for scenes and buttons.
-### Changed
 - `episodes/episode1` example demonstrates hidden choices.
-## [0.1.4] - 2025-07-03
-### Added
 - Button on the episode selection screen to return to the title.
-### Fixed
 - Starting Episode 1 after completing the tutorial now works reliably.
-## [0.1.3] - 2025-07-02
-### Fixed
 - Missing `continueBtn` definition prevented the "Insert Tape" button from working.
-## [0.1.2] - 2025-07-01
-### Added
 - Noted early development status in README and AGENTS.
-### Changed
 - CHANGELOG now lists releases in reverse chronological order.
 
-## [0.1.1] - 2025-06-30
+## [0.0.0.1] - 2025-06-30
 ### Added
 - Save progress across sessions with a Continue option.
-### Changed
 - Restarting the game now clears saved progress.
-
-## [0.0.4.4] - 2025-06-29
-### Added
 - Tutorial episode accessible from the menu.
-
-## [0.0.4.3] - 2025-06-28
-### Added
 - Tip on using built-in CSS classes in the writing guide.
-### Changed
 - README now explains how to run the test script.
-
-## [0.0.4.2] - 2025-06-27
-### Added
 - Mute controls for background static and button click sounds.
 - Global click sound plays when any button is pressed.
-### Changed
 - Static and click audio now respect the mute settings.
-
-## [0.0.4.1] - 2025-06-26
-### Added
 - Embedded episode data so the game works when opened directly from the file system.
-### Changed
 - Improved README with clearer instructions.
-### Fixed
 - Episode selection now loads correctly without a web server.
-
-## [0.1] - 2025-06-25
-### Changed
 - Renumbered previous releases under the 0.0.x scheme.
-
-## [0.0.4.0] - 2025-06-25
-### Added
 - Basic sound effects when navigating scenes.
 - Scene navigation history overlay.
 - Package.json with a simple test script.
 - Dedicated folder for audio assets.
-### Changed
 - Tweaked animation speed and scene transition timing.
-### Fixed
 - Minor bugs discovered during playtesting.
-
-## [0.0.3.1] - 2025-06-24
-### Added
 - Smooth fade transitions when moving between screens and scenes.
-
-## [0.0.3.0] - 2025-06-24
-### Added
 - SEO meta description and Open Graph tags.
 - ARIA roles for interactive scenes.
 - Externalized CSS and JavaScript files (`style.css` and `script.js`).
-
-## [0.0.2.0] - 2025-06-24
-### Added
 - Episode selection screen that lets you choose which episode to play.
 
 ## [Future]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Image assets are stored in the `images` folder. Sound effects and music live in 
 4. After editing an episode's `.json`, run `npm run build-episodes` to regenerate the `.js` version and then run `npm test` to catch any issues.
 5. Use the **Dev Tools** button on the title screen if you need to clear saved progress.
 
+## Versioning
+
+The project uses simple incremental build numbers in the form
+`MAJOR.MODERATE.MINOR.HOTFIX`. Only the last digit increases for each
+release. See [VERSIONING.md](VERSIONING.md) for more details.
+
 ## License
 
 This project is licensed under the **Creative Commons Attribution-NonCommercial 4.0 International License**. See the [LICENSE](LICENSE) file for details.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,15 @@
+# Versioning
+
+This project uses a simple four-part build number: `MAJOR.MODERATE.MINOR.HOTFIX`.
+Only the hotfix digit increments for each release. Changes from several days may
+be grouped under one number when they are small.
+
+To publish a new version:
+
+1. Add your changes to `CHANGELOG.md` under the latest heading.
+2. Bump the build number and update the date.
+3. Run `npm test` to ensure all checks pass. If you changed any episode JSON,
+   run `npm run build-episodes` first.
+
+The numbers do not reflect API stability—they just provide an ordered list of
+releases.


### PR DESCRIPTION
## Summary
- collapse changelog entries into five grouped releases
- describe build number scheme in new `VERSIONING.md`
- link to the versioning file from the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c9dc18b84832aad78be2466c9b7ee