### PR TITLE
Add UI runtime tests

### DIFF
--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -24,36 +24,107 @@ function createAudioElement() {
   };
 }
 
-function setupDOM() {
-  const elements = {
-    'sfx-click': createAudioElement(),
-    'sfx-static': createAudioElement(),
-    'tape-fx': createAudioElement(),
-    'title-music': createAudioElement(),
-    'title-music2': createAudioElement(),
-    'mute-music-btn': { textContent: '' },
-    'mute-sfx-btn': { textContent: '' },
-    'music-volume': { value: 1 },
-    'sfx-volume': { value: 1 }
+const elements = {};
+
+function createDomElement(tag = 'div') {
+  const el = {
+    tagName: tag.toUpperCase(),
+    _id: '',
+    _className: '',
+    style: { display: 'none' },
+    textContent: '',
+    innerHTML: '',
+    dataset: {},
+    children: [],
+    parentNode: null,
+    classList: {
+      classes: [],
+      add(cls) { if (!this.classes.includes(cls)) this.classes.push(cls); },
+      remove(cls) { this.classes = this.classes.filter(c => c !== cls); },
+      contains(cls) { return this.classes.includes(cls); }
+    },
+    appendChild(child) { child.parentNode = this; this.children.push(child); },
+    querySelector(selector) {
+      if (selector === '.choice-btn') {
+        return this.children.find(c => c.classList && c.classList.contains('choice-btn')) || null;
+      }
+      return null;
+    },
+    querySelectorAll() { return []; },
+    setAttribute(attr, val) {
+      if (attr === 'id') {
+        this.id = val;
+      } else if (attr === 'class') {
+        this.className = val;
+      } else {
+        this[attr] = val;
+      }
+    },
+    addEventListener(type, handler) {
+      if (type === 'transitionend') handler();
+    },
+    removeEventListener() {},
+    scrollIntoView() {},
+    focus() { this.focused = true; }
   };
+  Object.defineProperty(el, 'id', {
+    get() { return this._id; },
+    set(val) { this._id = val; elements[val] = this; }
+  });
+  Object.defineProperty(el, 'className', {
+    get() { return this._className; },
+    set(val) {
+      this._className = val;
+      this.classList.classes = [];
+      val.split(/\s+/).forEach(c => { if (c) this.classList.add(c); });
+    }
+  });
+  return el;
+}
+
+function setupDOM() {
+  const ids = [
+    'sfx-click', 'sfx-static', 'tape-fx',
+    'title-music', 'title-music2',
+    'mute-music-btn', 'mute-sfx-btn',
+    'music-volume', 'sfx-volume',
+    'back-btn', 'vhs-screen', 'scene-announcer'
+  ];
+  ids.forEach(id => { elements[id] = id.includes('music') || id.includes('sfx') || id === 'tape-fx' || id.startsWith('title-') ? createAudioElement() : createDomElement(id === 'music-volume' || id === 'sfx-volume' ? 'input' : 'div'); });
+  elements['mute-music-btn'].textContent = '';
+  elements['mute-sfx-btn'].textContent = '';
+  elements['music-volume'].value = 1;
+  elements['sfx-volume'].value = 1;
+  elements['back-btn'].disabled = false;
   global.document = {
     getElementById: id => elements[id] || null,
+    querySelector(selector) {
+      if (selector === '.interactive-scene.visible') {
+        return Object.values(elements).find(e => e.classList && e.classList.contains('interactive-scene') && e.classList.contains('visible')) || null;
+      }
+      return null;
+    },
+    querySelectorAll() { return []; },
+    createElement: tag => createDomElement(tag),
     addEventListener: () => {}
   };
   return elements;
 }
 
-function runTests() {
+async function runTests() {
   const storage = createStubStorage();
   global.window = {};
   global.localStorage = storage;
   global.DOMException = global.DOMException || class extends Error {};
-  const elements = setupDOM();
+  setupDOM();
   global.requestAnimationFrame = fn => fn(0);
   global.performance = { now: () => 0 };
 
   require('../state.js');
   require('../audio.js');
+
+  global.StateModule = global.window.StateModule;
+  global.AudioModule = global.window.AudioModule;
 
   const State = global.window.StateModule;
   const Audio = global.window.AudioModule;
@@ -95,6 +166,49 @@ function runTests() {
   Audio.stopVhsSound();
   assert.strictEqual(elements['sfx-static'].paused, true);
   assert.strictEqual(elements['sfx-static'].currentTime, 0);
+
+  // UI module tests
+  require('../ui.js');
+  const Ui = global.window.UiModule;
+
+  // Minimal scene elements after loading ui.js
+  const screen = elements['vhs-screen'];
+  const scene1 = document.createElement('div');
+  scene1.id = 'scene1';
+  scene1.classList.add('interactive-scene');
+  const btn1 = document.createElement('button');
+  btn1.classList.add('choice-btn');
+  scene1.appendChild(btn1);
+  screen.appendChild(scene1);
+
+  const scene2 = document.createElement('div');
+  scene2.id = 'scene2';
+  scene2.classList.add('interactive-scene');
+  const btn2 = document.createElement('button');
+  btn2.classList.add('choice-btn');
+  scene2.appendChild(btn2);
+  screen.appendChild(scene2);
+
+  global.fetch = () => Promise.reject(new Error('offline'));
+  global.window.localEpisodes = {
+    episode1: { start: 'scene1', scenes: [
+      { id: 'scene1', html: '<button class="choice-btn" data-scene="scene2">Next</button>' },
+      { id: 'scene2', html: '<p>End</p>' }
+    ] }
+  };
+
+  await Ui.loadEpisode('1');
+  assert.strictEqual(document.querySelector('.interactive-scene.visible').id, 'scene1');
+  assert.strictEqual(elements['back-btn'].textContent, 'Home');
+
+  await Ui.goToScene('scene2');
+  assert.strictEqual(document.querySelector('.interactive-scene.visible').id, 'scene2');
+  assert.strictEqual(elements['back-btn'].textContent, '\u2190 Back');
+  assert.strictEqual(global.window.StateModule.getProgress().scene, 'scene2');
+
+  await Ui.goToScene('scene1', true);
+  assert.strictEqual(document.querySelector('.interactive-scene.visible').id, 'scene1');
+  assert.strictEqual(elements['back-btn'].textContent, 'Home');
 }
 
 runTests();


### PR DESCRIPTION
## Summary
- enhance test DOM with minimal element model
- add async UI tests covering scene transitions and back button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ca46ebcd8832ab212360c71e249c5