### PR TITLE
Add ESLint setup and lint command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "globals": {
+    "StateModule": "readonly",
+    "AudioModule": "readonly",
+    "UiModule": "readonly"
+  },
+  "rules": {
+    "semi": ["error", "always"],
+    "no-var": "error"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,4 +81,5 @@ All notable changes to this project will be documented in this file.
 ## [Future]
 ### Added
 - Branch point in Episode 1 allowing players to play, investigate, or destroy the tape.
+- Local ESLint setup with a `lint` script for checking code style.
 Planned enhancements and updates will be listed here as they are decided.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Image assets are stored in the `images` folder. Sound effects and music live in 
 1. Clone or download this repository.
 2. Either open `index.html` directly or serve the folder with a simple HTTP server (`npx http-server` works nicely). Episode data is embedded so it works offline.
 3. Run `npm install` (if needed) and `npm test` to verify required files and script syntax.
-4. After editing an episode's `.json`, run `npm run build-episodes` to regenerate the `.js` version and then run `npm test` to catch any issues.
-5. Use the **Dev Tools** button on the title screen if you need to clear saved progress.
+4. Run `npm run lint` to check code style and catch common mistakes.
+5. After editing an episode's `.json`, run `npm run build-episodes` to regenerate the `.js` version and then run `npm test` to catch any issues.
+6. Use the **Dev Tools** button on the title screen if you need to clear saved progress.
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
   "scripts": {
     "test": "node test/check.js",
     "embed": "node scripts/embedEpisodes.js",
-    "build-episodes": "node scripts/embedEpisodes.js"
+    "build-episodes": "node scripts/embedEpisodes.js",
+    "lint": "eslint -c .eslintrc.json ."
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "eslint": "8.57.1"
+  }
 }


### PR DESCRIPTION
## Summary
- define a basic `.eslintrc.json` enforcing semicolons and banning `var`
- add local ESLint dev dependency and `lint` script
- document the lint step in the README
- ignore `node_modules` and `package-lock.json`
- note the new lint script in the changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ca6a2db10832a89b76dbc53d09431