### PR TITLE
Add audio playback helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.8] - 2025-07-28
+### Added
+- Utility function `playAudioElement` to handle volume-aware playback.
+- `playVhsSound`, `playSceneSound`, `playTitleMusic`, and `playTitleMusic2` now use the new helper.
+
 ## [0.0.0.7] - 2025-07-27
 ### Added
 - `ACT1_DRAFT.md` containing the full first act script.

--- a/audio.js
+++ b/audio.js
@@ -29,20 +29,26 @@
       }
   }
 
-  function playVhsSound() {
-      if (sfxStatic && sfxStatic.paused && !musicMuted) {
-          sfxStatic.volume = musicVolume;
-          sfxStatic.currentTime = 0;
-          sfxStatic.play();
+  function playAudioElement(el, volume, muted, onlyIfPaused = false) {
+      if (!el || muted) return;
+      if (!onlyIfPaused || el.paused) {
+          el.volume = volume;
+          el.currentTime = 0;
+          const playPromise = el.play();
+          if (playPromise && typeof playPromise.catch === 'function') {
+              playPromise.catch(() => {
+                  document.addEventListener('click', () => el.play(), { once: true });
+              });
+          }
       }
   }
 
+  function playVhsSound() {
+      playAudioElement(sfxStatic, musicVolume, musicMuted, true);
+  }
+
   function playSceneSound() {
-      if (sfxStatic && sfxStatic.paused && !musicMuted) {
-          sfxStatic.volume = musicVolume;
-          sfxStatic.currentTime = 0;
-          sfxStatic.play();
-      }
+      playAudioElement(sfxStatic, musicVolume, musicMuted, true);
   }
 
   function playClickSound() {
@@ -87,14 +93,8 @@
   }
 
   function playTitleMusic() {
+      playAudioElement(titleMusic, musicVolume, musicMuted);
       if (titleMusic && !musicMuted) {
-          titleMusic.currentTime = 0;
-          const playPromise = titleMusic.play();
-          if (playPromise && typeof playPromise.catch === 'function') {
-              playPromise.catch(() => {
-                  document.addEventListener('click', () => titleMusic.play(), { once: true });
-              });
-          }
           fadeInAudio(titleMusic, 3000, musicVolume);
       }
   }
@@ -107,14 +107,8 @@
   }
 
   function playTitleMusic2() {
+      playAudioElement(titleMusic2, musicVolume, musicMuted);
       if (titleMusic2 && !musicMuted) {
-          titleMusic2.currentTime = 0;
-          const playPromise = titleMusic2.play();
-          if (playPromise && typeof playPromise.catch === 'function') {
-              playPromise.catch(() => {
-                  document.addEventListener('click', () => titleMusic2.play(), { once: true });
-              });
-          }
           fadeInAudio(titleMusic2, 3000, musicVolume);
       }
   }


### PR DESCRIPTION
## Summary
- centralize audio play logic in a new `playAudioElement` helper
- update playback functions to use the new helper
- document change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d25e1132c832aad1d596b271fcea8