### PR TITLE
Build script auto-updates service worker cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.10] - 2025-07-30
+### Added
+- Service worker cache is now generated automatically when running `npm run build-episodes`.
+
 ## [0.0.0.9] - 2025-07-29
 ### Changed
 - `initAudio` now resumes the audio context when suspended.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Episode 1 is playable and features sound effects and a scene history overlay. P
 
 ## Writing Episodes
 
-All episode data resides in the `episodes` folder. Each file is a JSON document describing a list of scenes. Writers can follow the structure documented in [WRITING_GUIDE.md](WRITING_GUIDE.md) to create new episodes. After editing a `.json` file, run `npm run build-episodes` to regenerate the embedded `.js` and commit both files.
+All episode data resides in the `episodes` folder. Each file is a JSON document describing a list of scenes. Writers can follow the structure documented in [WRITING_GUIDE.md](WRITING_GUIDE.md) to create new episodes. After editing a `.json` file, run `npm run build-episodes` to regenerate the embedded `.js`, update `sw.js` with the correct cache list, and commit both files.
 For a broader sense of tone and structure, see [SCRIPT_GUIDELINES.md](SCRIPT_GUIDELINES.md), which contains an example script and style notes. A full draft of Act&nbsp;1 lives in [ACT1_DRAFT.md](ACT1_DRAFT.md).
 Image assets are stored in the `images` folder. Sound effects and music live in the `audio` folder.
 
@@ -18,7 +18,7 @@ Image assets are stored in the `images` folder. Sound effects and music live in 
 2. Either open `index.html` directly or serve the folder with a simple HTTP server (`npx http-server` works nicely). Episode data is embedded so it works offline.
 3. Run `npm install` (if needed) and `npm test` to verify required files and script syntax.
 4. Run `npm run lint` to check code style and catch common mistakes.
-5. After editing an episode's `.json`, run `npm run build-episodes` to regenerate the `.js` version and then run `npm test` to catch any issues.
+5. After editing an episode's `.json`, run `npm run build-episodes` to regenerate the `.js` files and update `sw.js`, then run `npm test` to catch any issues.
 6. Use the **Dev Tools** button on the title screen if you need to clear saved progress.
 
 ## Versioning

--- a/scripts/embedEpisodes.js
+++ b/scripts/embedEpisodes.js
@@ -18,3 +18,25 @@ files.forEach(file => {
 });
 
 console.log('Embedded', files.length, 'episodes');
+
+// Update sw.js cache list with all episode files
+try {
+  const swPath = path.join(__dirname, '..', 'sw.js');
+  const swLines = fs.readFileSync(swPath, 'utf8').split(/\r?\n/);
+  const start = swLines.findIndex(l => l.includes("'episodes/"));
+  if (start !== -1) {
+    let end = start;
+    while (end < swLines.length && /'episodes\//.test(swLines[end])) end++;
+    const episodeFiles = fs.readdirSync(episodesDir)
+      .filter(f => f.endsWith('.json') || f.endsWith('.js'))
+      .sort();
+    const newLines = episodeFiles.map(f => `      'episodes/${f}',`);
+    swLines.splice(start, end - start, ...newLines);
+    fs.writeFileSync(swPath, swLines.join('\n'));
+    console.log('Updated sw.js with', episodeFiles.length, 'episode files');
+  } else {
+    console.error('Could not find episode block in sw.js');
+  }
+} catch (err) {
+  console.error('Failed to update sw.js:', err);
+}

--- a/test/check.js
+++ b/test/check.js
@@ -132,6 +132,23 @@ for (const jsonFile of episodeJsons) {
   }
 }
 
+// Ensure service worker caches all episode files
+const swPath = path.join(__dirname, '..', 'sw.js');
+try {
+  const swContent = fs.readFileSync(swPath, 'utf8');
+  const episodeFiles = fs.readdirSync(episodesDir)
+    .filter(f => f.endsWith('.json') || f.endsWith('.js'));
+  for (const file of episodeFiles) {
+    if (!swContent.includes(`'episodes/${file}'`)) {
+      console.error(`sw.js missing ${file} in cache list`);
+      missing = true;
+    }
+  }
+} catch (err) {
+  console.error('Unable to verify sw.js:', err.message);
+  missing = true;
+}
+
 // Run additional runtime tests
 try {
   require('./runtime.test.js');


### PR DESCRIPTION
## Summary
- extend `scripts/embedEpisodes.js` to patch `sw.js` with episode file names
- verify service worker episode cache in tests
- document new build step in README
- note change in CHANGELOG

## Testing
- `npm run build-episodes`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d2ba66404832abaf1a3a5e74d12c3