### PR TITLE
Improve embedEpisodes parse error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,4 +106,5 @@ All notable changes to this project will be documented in this file.
 - Local ESLint setup with a `lint` script for checking code style.
 - Added `SCRIPT_GUIDELINES.md` with a narrative script reference.
 - Test now validates JSON in `data-set-state` and `data-show-if` attributes.
+- `embedEpisodes.js` now reports parse errors with the file name and exits with a non-zero status.
 Planned enhancements and updates will be listed here as they are decided.

--- a/scripts/embedEpisodes.js
+++ b/scripts/embedEpisodes.js
@@ -7,7 +7,14 @@ const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.json'));
 
 files.forEach(file => {
   const jsonPath = path.join(episodesDir, file);
-  const jsonData = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  let jsonData;
+  try {
+    jsonData = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  } catch (err) {
+    console.error(`Failed to parse ${file}:`, err.message);
+    process.exit(1);
+  }
+
   const name = path.basename(file, '.json');
   const jsPath = path.join(episodesDir, `${name}.js`);
   const jsContent =

--- a/test/check.js
+++ b/test/check.js
@@ -149,6 +149,14 @@ try {
   missing = true;
 }
 
+// Ensure embedEpisodes.js handles invalid JSON
+try {
+  require('./embedScript.test.js');
+} catch (err) {
+  console.error(err);
+  missing = true;
+}
+
 // Run additional runtime tests
 try {
   require('./runtime.test.js');

--- a/test/embedScript.test.js
+++ b/test/embedScript.test.js
@@ -1,0 +1,29 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const episodesDir = path.join(__dirname, '..', 'episodes');
+const badFile = path.join(episodesDir, 'bad.json');
+
+// Create an invalid JSON file
+fs.writeFileSync(badFile, '{ invalid json }');
+
+// Run the embed script expecting failure
+const resultFail = spawnSync('node', [path.join(__dirname, '..', 'scripts', 'embedEpisodes.js')], { encoding: 'utf8' });
+
+// Clean up the invalid file
+fs.unlinkSync(badFile);
+
+if (resultFail.status === 0) {
+  throw new Error('embedEpisodes.js should fail on invalid JSON');
+}
+if (!(/bad\.json/.test(resultFail.stderr) || /bad\.json/.test(resultFail.stdout))) {
+  throw new Error('Error output should mention bad.json');
+}
+
+// Verify script succeeds when JSON is valid
+const resultSuccess = spawnSync('node', [path.join(__dirname, '..', 'scripts', 'embedEpisodes.js')], { encoding: 'utf8' });
+if (resultSuccess.status !== 0) {
+  throw new Error('embedEpisodes.js failed on valid episodes');
+}
+


### PR DESCRIPTION
## Summary
- handle JSON parse errors inside `embedEpisodes.js`
- add regression test for `embedEpisodes.js`
- run new test from `check.js`
- document new behaviour in `CHANGELOG.md`

## Testing
- `npm run build-episodes`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d2ca7ef88832a8db8e00c9acfd07f