### PR TITLE
Build-time service worker version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.11] - 2025-07-31
+### Changed
+- Service worker now embeds the build number during `npm run build-episodes`.
+
 ## [0.0.0.10] - 2025-07-30
 ### Added
 - Service worker cache is now generated automatically when running `npm run build-episodes`.

--- a/scripts/embedEpisodes.js
+++ b/scripts/embedEpisodes.js
@@ -30,6 +30,19 @@ console.log('Embedded', files.length, 'episodes');
 try {
   const swPath = path.join(__dirname, '..', 'sw.js');
   const swLines = fs.readFileSync(swPath, 'utf8').split(/\r?\n/);
+  // Update CACHE_NAME with current build number
+  try {
+    const changelog = fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf8');
+    const m = changelog.match(/\[(\d+\.\d+\.\d+\.\d+)\]/);
+    if (m) {
+      const idx = swLines.findIndex(l => l.includes('const CACHE_NAME'));
+      if (idx !== -1) {
+        swLines[idx] = `const CACHE_NAME = 'echo-tape-${m[1]}';`;
+      }
+    }
+  } catch (err) {
+    console.error('Failed to read build number:', err.message);
+  }
   const start = swLines.findIndex(l => l.includes("'episodes/"));
   if (start !== -1) {
     let end = start;

--- a/sw.js
+++ b/sw.js
@@ -1,21 +1,9 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-let CACHE_NAME = 'echo-tape-dev';
-
-async function getBuildNumber() {
-  try {
-    const text = await fetch('CHANGELOG.md', {cache: 'no-store'}).then(r => r.text());
-    const match = text.match(/\[(\d+\.\d+\.\d+\.\d+)\]/);
-    return match ? match[1] : 'dev';
-  } catch (err) {
-    return 'dev';
-  }
-}
+const CACHE_NAME = 'echo-tape-0.0.0.11';
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {
-    const build = await getBuildNumber();
-    CACHE_NAME = CACHE_PREFIX + build;
     const cache = await caches.open(CACHE_NAME);
     await cache.addAll([
       '/',
@@ -45,8 +33,6 @@ self.addEventListener('install', event => {
 
 self.addEventListener('activate', event => {
   event.waitUntil((async () => {
-    const build = await getBuildNumber();
-    CACHE_NAME = CACHE_PREFIX + build;
     const keys = await caches.keys();
     await Promise.all(keys.map(key => {
       if (key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME) {


### PR DESCRIPTION
## Summary
- update build script to stamp `CACHE_NAME` with current build number
- embed build number in `sw.js` and remove runtime fetch
- document change in `CHANGELOG.md`

## Testing
- `npm run build-episodes`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d2fa05660832ab6b1cc5ee147d66a