### PR TITLE
Add episode manifest and dynamic loader

### DIFF
--- a/dist/episodes/manifest.json
+++ b/dist/episodes/manifest.json
@@ -1,0 +1,4 @@
+[
+  "episode0",
+  "episode1"
+]

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -1,6 +1,6 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-const CACHE_NAME = 'echo-tape-0.0.0.12';
+const CACHE_NAME = 'echo-tape-0.0.0.13';
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {
@@ -18,6 +18,7 @@ self.addEventListener('install', event => {
       'episodes/episode1.json',
       'dist/episodes/episode0.js',
       'dist/episodes/episode1.js',
+      'dist/episodes/manifest.json',
       'audio/click.ogg',
       'audio/static.ogg',
       'audio/tape_fx.ogg',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.13] - 2025-08-02
+### Added
+- Build script now outputs `dist/episodes/manifest.json` listing episodes.
+- UI loads episode scripts dynamically based on this manifest.
+- Removed hardcoded episode `<script>` tags from `index.html`.
+
 ## [0.0.0.12] - 2025-08-01
 ### Changed
 - Converted core JavaScript files to ES modules and updated tests accordingly.

--- a/index.html
+++ b/index.html
@@ -83,9 +83,7 @@
     <audio id="sfx-static" src="audio/static.ogg" preload="auto" loop></audio>
     <audio id="tape-fx" src="audio/tape_fx.ogg" preload="auto"></audio>
 
-    <!-- Embedded episode data for offline use -->
-    <script src="dist/episodes/episode0.js"></script>
-    <script src="dist/episodes/episode1.js"></script>
+    <!-- Episode data will be loaded dynamically -->
     <script type="module" src="src/script.mjs"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/scripts/embedEpisodes.js
+++ b/scripts/embedEpisodes.js
@@ -26,6 +26,12 @@ files.forEach(file => {
   fs.writeFileSync(jsPath, jsContent);
 });
 
+// Write episode manifest for dynamic loading
+const manifest = files.map(f => path.basename(f, '.json')).sort();
+const manifestPath = path.join(__dirname, '..', 'dist', 'episodes', 'manifest.json');
+fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+console.log('Wrote manifest with', manifest.length, 'episodes');
+
 console.log('Embedded', files.length, 'episodes');
 
 // Update sw.js cache list with assets from episodes, audio, and images
@@ -65,14 +71,16 @@ try {
       .filter(f => f.endsWith(".json"))
       .sort()
       .map(f => `episodes/${f}`);
-    const episodeJsAssets = fs.readdirSync(path.join(__dirname, "..", "dist", "episodes"))
-      .filter(f => f.endsWith(".js"))
+    const distEpisodesDir = path.join(__dirname, '..', 'dist', 'episodes');
+    const episodeJsAssets = fs.readdirSync(distEpisodesDir)
+      .filter(f => f.endsWith('.js'))
       .sort()
       .map(f => `dist/episodes/${f}`);
+    const manifestAsset = ['dist/episodes/manifest.json'];
     const audioAssets = fs.readdirSync(audioDir).sort().map(f => `audio/${f}`);
     const imageAssets = fs.readdirSync(imagesDir).sort().map(f => `images/${f}`);
 
-    const assets = [...rootAssets, ...episodeAssets, ...episodeJsAssets,  ...audioAssets, ...imageAssets];
+    const assets = [...rootAssets, ...episodeAssets, ...episodeJsAssets, ...manifestAsset, ...audioAssets, ...imageAssets];
     const newLines = assets.map(a => `      '${a}',`);
     swLines.splice(start + 1, end - start - 1, ...newLines);
     fs.writeFileSync(swPath, swLines.join('\n'));

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -37,6 +37,21 @@ let currentEpisode = null;
 let resumeScene = null;
 let firstSceneId = null;
 
+async function loadEpisodeScripts() {
+    try {
+        const resp = await fetch('dist/episodes/manifest.json');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const names = await resp.json();
+        names.forEach(name => {
+            const script = document.createElement('script');
+            script.src = `dist/episodes/${name}.js`;
+            document.body.appendChild(script);
+        });
+    } catch (err) {
+        console.error('Failed to load episode scripts', err);
+    }
+}
+
 function showScreen(el) {
     el.style.display = 'flex';
     requestAnimationFrame(() => el.classList.add('visible'));
@@ -325,6 +340,7 @@ function handleKeydown(event) {
 
 function init() {
     document.addEventListener('keydown', handleKeydown);
+    loadEpisodeScripts();
 
     startBtn.addEventListener('click', () => {
         AudioModule.initAudio();

--- a/test/check.js
+++ b/test/check.js
@@ -155,6 +155,7 @@ try {
     'src/ui.mjs',
     ...fs.readdirSync(episodesDir).filter(f => f.endsWith(".json")).map(f => `episodes/${f}`),
     ...fs.readdirSync(path.join(__dirname, "..", "dist", "episodes")).filter(f => f.endsWith(".js")).map(f => `dist/episodes/${f}`),
+    'dist/episodes/manifest.json',
     ...fs.readdirSync(audioDir).map(f => `audio/${f}`),
     ...fs.readdirSync(imagesDir).map(f => `images/${f}`)
   ];


### PR DESCRIPTION
## Summary
- create `dist/episodes/manifest.json` during the build step
- include manifest in service worker asset list
- update UI to fetch the manifest and dynamically load episode scripts
- remove hardcoded episode script tags from `index.html`
- document the change in `CHANGELOG.md`
- update tests for the new manifest file

## Testing
- `npm run build-episodes`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d3e6dc074832a8d655bb206c96dc8