### PR TITLE
Add episode load failure message

### DIFF
--- a/dist/sw.js
+++ b/dist/sw.js
@@ -1,6 +1,6 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-const CACHE_NAME = 'echo-tape-0.0.0.13';
+const CACHE_NAME = 'echo-tape-0.0.0.14';
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.14] - 2025-08-03
+### Added
+- In-game message with retry option when an episode fails to load.
+
 ## [0.0.0.13] - 2025-08-02
 ### Added
 - Build script now outputs `dist/episodes/manifest.json` listing episodes.

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -69,6 +69,8 @@ function hideScreen(el) {
 }
 
 async function loadEpisode(ep) {
+    const screen = document.getElementById('vhs-screen');
+    if (!screen) return;
     let data;
     try {
         const resp = await fetch(`episodes/episode${ep}.json`);
@@ -80,11 +82,15 @@ async function loadEpisode(ep) {
             data = window.localEpisodes[`episode${ep}`];
         } else {
             console.error('Episode data not found');
+            screen.innerHTML =
+                '<div class="dialogue">Failed to load episode. ' +
+                'Please check your connection and try again.</div>' +
+                '<button id="retry-load-btn" class="choice-btn">Retry</button>';
+            const retryBtn = document.getElementById('retry-load-btn');
+            if (retryBtn) retryBtn.addEventListener('click', () => loadEpisode(ep));
             return;
         }
     }
-    const screen = document.getElementById('vhs-screen');
-    if (!screen) return;
 
     screen.innerHTML = '';
 

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -207,6 +207,12 @@ async function runTests() {
   await Ui.goToScene('scene1', true);
   assert.strictEqual(document.querySelector('.interactive-scene.visible').id, 'scene1');
   assert.strictEqual(elements['back-btn'].textContent, 'Home');
+
+  delete global.window.localEpisodes;
+  await Ui.loadEpisode('99');
+  const errHtml = document.getElementById('vhs-screen').innerHTML;
+  assert.ok(/Failed to load episode/i.test(errHtml));
+  assert.ok(errHtml.includes('retry-load-btn'));
 }
 
 runTests();


### PR DESCRIPTION
## Summary
- show a retry message when an episode cannot be loaded
- test that the message appears on fetch failure
- bump service worker cache version
- document the change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d4091f818832a802f44cb2a9c7aa6