### PR TITLE
Use package version for cache name

### DIFF
--- a/dist/sw.js
+++ b/dist/sw.js
@@ -1,6 +1,6 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-const CACHE_NAME = 'echo-tape-0.0.0.14';
+const CACHE_NAME = 'echo-tape-1.0.0';
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,15 +1,15 @@
 # Versioning
 
-This project uses a simple four-part build number: `MAJOR.MODERATE.MINOR.HOTFIX`.
-Only the hotfix digit increments for each release. Changes from several days may
-be grouped under one number when they are small.
+The release number lives in the `version` field of `package.json` and follows a
+standard `MAJOR.MINOR.PATCH` format. The build script reads this value and
+embeds it into the service worker’s `CACHE_NAME`. Bumping the version forces
+users to fetch a new cache of the application.
 
 To publish a new version:
 
 1. Add your changes to `CHANGELOG.md` under the latest heading.
-2. Bump the build number and update the date.
-3. Run `npm test` to ensure all checks pass. If you changed any episode JSON,
-   run `npm run build-episodes` first.
+2. Update the `version` in `package.json`.
+3. If you changed any episode JSON, run `npm run build-episodes`.
+4. Run `npm test` to ensure all checks pass before committing.
 
-The numbers do not reflect API stability—they just provide an ordered list of
-releases.
+The numbers are purely for ordering releases and do not imply API stability.

--- a/scripts/embedEpisodes.js
+++ b/scripts/embedEpisodes.js
@@ -39,18 +39,16 @@ try {
   const swPath = path.join(__dirname, '..', 'dist', 'sw.js');
   const swLines = fs.readFileSync(swPath, 'utf8').split(/\r?\n/);
 
-  // Update CACHE_NAME with current build number
+  // Update CACHE_NAME with version from package.json
   try {
-    const changelog = fs.readFileSync(path.join(__dirname, '..', 'docs/CHANGELOG.md'), 'utf8');
-    const m = changelog.match(/\[(\d+\.\d+\.\d+\.\d+)\]/);
-    if (m) {
-      const idx = swLines.findIndex(l => l.includes('const CACHE_NAME'));
-      if (idx !== -1) {
-        swLines[idx] = `const CACHE_NAME = 'echo-tape-${m[1]}';`;
-      }
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+    const version = pkg.version || 'dev';
+    const idx = swLines.findIndex(l => l.includes('const CACHE_NAME'));
+    if (idx !== -1) {
+      swLines[idx] = `const CACHE_NAME = 'echo-tape-${version}';`;
     }
   } catch (err) {
-    console.error('Failed to read build number:', err.message);
+    console.error('Failed to read package.json version:', err.message);
   }
 
   const start = swLines.findIndex(l => l.includes('ASSETS_START'));

--- a/test/check.js
+++ b/test/check.js
@@ -143,6 +143,12 @@ try {
   }
 
   const swContent = fs.readFileSync(swPath, 'utf8');
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+  const expectedCacheLine = `const CACHE_NAME = 'echo-tape-${pkg.version}'`;
+  if (!swContent.includes(expectedCacheLine)) {
+    console.error(`CACHE_NAME not updated to ${pkg.version}`);
+    missing = true;
+  }
   const audioDir = path.join(__dirname, '..', 'audio');
   const imagesDir = path.join(__dirname, '..', 'images');
   const assets = [


### PR DESCRIPTION
## Summary
- embedEpisodes.js reads `package.json` for the version when generating `sw.js`
- update tests to check that the service worker cache name matches `package.json` version
- document new scheme in VERSIONING.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d41b1b6f4832a9572c37da7a3f2f8