### PR TITLE
Improve Episode 1 intro audio and layout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.20] - 2025-06-28
+### Changed
+- Intro music loops during Episode 1 crawl.
+- Wider text area for the Episode 1 intro crawl.
+
 ## [0.0.0.19] - 2025-06-27
 ### Added
 - Intro music for Episode 1 crawl using `introEP1.ogg`.

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
 
     <audio id="title-music" src="audio/titleMusic.ogg" preload="auto" loop></audio>
     <audio id="title-music2" src="audio/titleMusic2.ogg" preload="auto" loop></audio>
-    <audio id="intro-music" src="audio/introEP1.ogg" preload="auto"></audio>
+    <audio id="intro-music" src="audio/introEP1.ogg" preload="auto" loop></audio>
     <audio id="sfx-click" src="audio/click.ogg" preload="auto"></audio>
     <audio id="sfx-static" src="audio/static.ogg" preload="auto" loop></audio>
     <audio id="tape-fx" src="audio/tape_fx.ogg" preload="auto"></audio>

--- a/src/audio.mjs
+++ b/src/audio.mjs
@@ -10,6 +10,7 @@ const introMusic = document.getElementById('intro-music');
 if (sfxStatic) sfxStatic.loop = true;
 if (titleMusic) titleMusic.loop = true;
 if (titleMusic2) titleMusic2.loop = true;
+if (introMusic) introMusic.loop = true;
 
 let audioCtx;
 let musicMuted = false;

--- a/style.css
+++ b/style.css
@@ -94,7 +94,7 @@ body {
 .intro-text {
     font-size: 1.3em;
     color: #ccc;
-    max-width: 700px;
+    max-width: 900px;
     margin: 50px auto;
     line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
- widen the intro crawl text container
- loop the Episode 1 intro music
- document the changes in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d70b964b8832aa5d63e174062832f