### PR TITLE
Adjust intro timing and image size

### DIFF
--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -183,10 +183,10 @@ function playIntro(ep) {
     introTimers = [];
     introTimers.push(setTimeout(() => {
         introTitle.classList.add('visible');
-    }, 18000));
+    }, 25000));
     introTimers.push(setTimeout(async () => {
         await startEpisode(selectedEpisode);
-    }, 22000));
+    }, 30000));
 }
 
 function restartGame() {

--- a/style.css
+++ b/style.css
@@ -109,7 +109,7 @@ body {
 
 .intro-crawl .intro-text {
     transform-origin: 50% 100%;
-    animation: star-crawl 18s linear forwards;
+    animation: star-crawl 25s linear forwards;
     font-size: 1.8em;
 }
 
@@ -413,6 +413,7 @@ body {
 .scene-image {
     max-width: 100%;
     height: auto;
+    max-height: 50vh;
     border: 2px solid #ff00ff;
     margin: 15px 0;
 }


### PR DESCRIPTION
## Summary
- slow down the intro crawl animation
- hold on the intro screen for a few more seconds before episode start
- reduce scene image height so less scrolling is required

## Testing
- `npm run build-episodes`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d7233c6d8832ab7cae75669eba464