### PR TITLE
Add additional game state keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.21] - 2025-06-29
+### Added
+- Game state now tracks `reviewedCaseFile`, `trustBroken`, and `visitedLarkhill` for future branching.
+
 ## [0.0.0.20] - 2025-06-28
 ### Changed
 - Intro music loops during Episode 1 crawl.

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -3,6 +3,9 @@
 const defaultState = {
     awareOfLoop: false,
     hasTape: false,
+    reviewedCaseFile: false,
+    trustBroken: false,
+    visitedLarkhill: false,
     musicMuted: false,
     sfxMuted: false,
     musicVolume: 1,
@@ -79,7 +82,10 @@ function updateStateSummary() {
     if (summary) {
         const awareText = gameState.awareOfLoop ? 'You know the loop is real.' : 'You remain unaware of the loop.';
         const itemText = gameState.hasTape ? 'The tape is in your possession.' : 'The tape is nowhere to be found.';
-        summary.textContent = awareText + ' ' + itemText;
+        const caseFileText = gameState.reviewedCaseFile ? 'You studied the case file.' : 'You have yet to read the case file.';
+        const trustText = gameState.trustBroken ? 'Distrust festers between you.' : 'Trust remains intact.';
+        const laneText = gameState.visitedLarkhill ? 'Larkhill Lane has been explored.' : 'Larkhill Lane is still a mystery.';
+        summary.textContent = [awareText, itemText, caseFileText, trustText, laneText].join(' ');
     }
 }
 

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -135,6 +135,9 @@ async function runTests() {
   assert.deepStrictEqual(JSON.parse(storage.store.echoTapeState), {
     awareOfLoop: false,
     hasTape: true,
+    reviewedCaseFile: false,
+    trustBroken: false,
+    visitedLarkhill: false,
     musicMuted: false,
     sfxMuted: false,
     musicVolume: 1,


### PR DESCRIPTION
## Summary
- expand default game state with new variables
- display new variables in the state summary
- adjust runtime tests for new state
- document state additions in the changelog

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dbfc9a970832aa78dca7eeb2db716