### PR TITLE
Expand Episode 1 scenes

### DIFF
--- a/dist/episodes/episode1.js
+++ b/dist/episodes/episode1.js
@@ -119,7 +119,7 @@ window.localEpisodes["episode1"] = {
     },
     {
       "id": "scene-paranoia-path",
-      "html": "<div class=\"dialogue\">\n                    <span class=\"character newt\">NEWT:</span> How do I know you didn't plant it? This is your office!\n                </div>\n                <div class=\"dialogue\">\n                    <span class=\"character joe\">JOE:</span> My mess? You're the one getting spooky notes from your gran!\n                </div>\n                <div class=\"choice-container\">\n                    <p>The trust shatters. Newt storms out with the tape.</p>\n                    <button class=\"choice-btn\" data-scene='scene-tobecontinued'>TO BE CONTINUED...</button>\n                </div>"
+      "html": "<div class=\"dialogue\">\n                    <span class=\"character newt\">NEWT:</span> How do I know you didn't plant it? This is your office!\n                </div>\n                <div class=\"dialogue\">\n                    <span class=\"character joe\">JOE:</span> My mess? You're the one getting spooky notes from your gran!\n                </div>\n                <div class=\"choice-container\">\n                    <p>The trust shatters. Newt storms out with the tape.</p>\n                    <button class=\"choice-btn\" data-set-state='{\"trustBroken\":true}' data-scene='scene-tobecontinued'>TO BE CONTINUED...</button>\n                </div>"
     },
     {
       "id": "scene-destroy-tape",
@@ -155,11 +155,51 @@ window.localEpisodes["episode1"] = {
     },
     {
       "id": "scene-pre-party",
-      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> Bass rumbles the walls. Friends chatter nervously. Somewhere outside, a siren wails like a warning.\n                </div>\n                <div class=\"choice-container\">\n                    <p>The party is about to begin.</p>\n                    <button class=\"choice-btn\" data-restart>End demo.</button>\n                </div>"
+      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> Bass rumbles the walls. Friends chatter nervously. Somewhere outside, a siren wails like a warning.\n                </div>\n                <div class=\"choice-container\">\n                    <p>The party is about to begin.</p>\n                    <button class=\"choice-btn\" data-scene='scene-party-begins'>Let the party begin</button>\n                </div>"
+    },
+    {
+      "id": "scene-party-begins",
+      "html": "<div class=\"dialogue\"><span class=\"character system\">SYSTEM:</span> The lights dim as the flat fills with friends. A scratched trance record spins, rattling the windows. The tape sits on the table like an idol.</div><div class=\"choice-container\"><p>What do you do?</p><button class=\"choice-btn\" data-scene='scene-show-tape'>Show everyone the tape</button><button class=\"choice-btn\" data-scene='scene-keep-hidden'>Keep it hidden for now</button></div>"
+    },
+    {
+      "id": "scene-show-tape",
+      "html": "<div class=\"dialogue\"><span class=\"character newt\">NEWT:</span> Yo, check this out!</div><div class=\"dialogue\"><span class=\"character system\">SYSTEM:</span> A hush falls over the room as the VCR whirs. Static leaks from the speakers.</div><div class=\"choice-container\"><button class=\"choice-btn\" data-scene='scene-visions'>Watch together</button></div>"
+    },
+    {
+      "id": "scene-keep-hidden",
+      "html": "<div class=\"dialogue\"><span class=\"character joe\">JOE:</span> Let's enjoy the night first.</div><div class=\"dialogue\"><span class=\"character system\">SYSTEM:</span> The tape vibrates angrily inside the drawer.</div><div class=\"choice-container\"><button class=\"choice-btn\" data-scene='scene-visions'>Rejoin the party</button></div>"
+    },
+    {
+      "id": "scene-visions",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> The music warps. Guests blur like smeared film. Gooby and Doobie stare at a door that shouldn't exist.</div><div class='choice-container'><p>The door beckons.</p><button class='choice-btn' data-scene='scene-enter-door'>Open it</button><button class='choice-btn' data-scene='scene-ignore-door'>Ignore it</button></div>"
+    },
+    {
+      "id": "scene-ignore-door",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> Each time you look away, the door creeps closer. Whispers about loops spread among the partygoers.</div><div class='choice-container'><button class='choice-btn' data-scene='scene-enter-door'>Open the door anyway</button></div>"
+    },
+    {
+      "id": "scene-enter-door",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> The handle is ice cold. Beyond lies a corridor lined with VHS tapes, humming softly.</div><div class='choice-container'><p>Cross the threshold?</p><button class='choice-btn' data-scene='scene-larkhill-field' data-set-state='{\"visitedLarkhill\":true}'>Step through</button></div>"
+    },
+    {
+      "id": "scene-larkhill-field",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> Night air hits you. You're standing on Larkhill Lane. In the grass, a camera blinks red.</div><div class='choice-container'><p>How will you end this?</p><button class='choice-btn' data-scene='scene-record-ending'>Record your own ending</button><button class='choice-btn' data-scene='scene-stop-tape'>Search for the STOP tape</button></div>"
+    },
+    {
+      "id": "scene-record-ending",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> You hit RECORD. The world shudders, then clears. Maybe this is freedom.</div><div class='choice-container'><button class='choice-btn' data-scene='scene-episode1-end'>Fade out</button></div>"
+    },
+    {
+      "id": "scene-stop-tape",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> You dig through the weeds and uncover a tape marked STOP. It hums with potential.</div><div class='choice-container'><button class='choice-btn' data-scene='scene-episode1-end'>Play it</button></div>"
+    },
+    {
+      "id": "scene-episode1-end",
+      "html": "<h2 style='color:#ff00ff;text-align:center;'>END OF EPISODE 1</h2><div class='dialogue' id='state-summary'></div><div class='choice-container'><button class='choice-btn' data-restart>Restart</button></div>"
     },
     {
       "id": "scene-case-file",
-      "html": "<div class=\"case-file\">\n<h2 class=\"case-header\">&gt;&gt; LARKHILL LANE // CASE FILE C-42</h2>\n<p class=\"case-status\">&gt; STATUS: UNLISTED... NOT REAL... NOT ENTIRELY</p>\n<div class=\"case-tabs\">\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-main\">&gt; CASE FILE</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-persons\">&gt; PERSONS OF INTEREST</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-evidence\">&gt; EVIDENCE</button>\n</div>\n<div id=\"cf-main\" class=\"case-tab-content\">\n<p>&gt; <span class=\"case-query\">QUERY:</span> PROPERTY VERIFICATION – NORTHWEST SECTOR C-42</p>\n<p>&gt; <span class=\"case-response\">ERROR - NO SUCH LISTING. FILE DOES NOT EXIST.</span></p>\n<h3>&gt; INCOMING TRANSMISSION... SOURCE: GRANNY (REAL ONE?)</h3>\n<button class=\"choice-btn case-play-audio\">&gt; PLAY AUDIO FRAGMENT</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"Tell Joe the property isn't listed anymore. Because it's not... real anymore. Not entirely... [STATIC]... Larkhill Lane.\"</p>\n</div>\n<div id=\"cf-persons\" class=\"case-tab-content\" style=\"display:none\">\n<h3>&gt; SUBJECT: JOE</h3>\n<p>&gt; <strong>STATUS:</strong> NUMB... AWAKENING</p>\n<p>&gt; <strong>AFFILIATION:</strong> HOME OFFICE (CIVIL SERVANT)</p>\n<p>&gt; <strong>PROFILE:</strong> Stocky frame, buzzed hair. Carries the weary warmth of forced smiles. A circuit-etched tattoo suggests a history with systems, logical and otherwise. Currently drawn into a system that defies logic.</p>\n<h3>&gt; SUBJECT: NEWT</h3>\n<p>&gt; <strong>STATUS:</strong> GROGGY... RECEPTIVE</p>\n<p>&gt; <strong>AFFILIATION:</strong> INDEPENDENT (SOUNDCLOUD ARTIST)</p>\n<p>&gt; <strong>PROFILE:</strong> Long blonde hair, sharp grin. A sly mischief in his eyes. Wears a slim gold chain. First point of contact for the anomalous transmission. Seems uniquely tuned to the unfolding weirdness.</p>\n<p>&gt; ASSOCIATES: DOOBIE &amp; GOOBY - Feline entities. Seemingly aware of the situation's gravity.</p>\n</div>\n<div id=\"cf-evidence\" class=\"case-tab-content\" style=\"display:none\">\n<div class=\"case-vhs\"></div>\n<p>&gt; ARTIFACT: VHS-C42</p>\n<p>&gt; Unmarked cassette discovered in a secure government facility. No case number assigned.</p>\n<p>&gt; Contents are... anomalous. Displays events that defy linear time.</p>\n<p class=\"case-vhs-status\">&gt; Artifact is dormant. Hover to detect energy signature.</p>\n<img src=\"images/joeNewtTape3.jpg\" alt=\"Distorted tape still\" class=\"case-evidence-image\">\n<button class=\"choice-btn case-play-audio\">&gt; PLAY ADDITIONAL AUDIO</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"There's more... the tape shows a door that isn't there.\"</p>\n</div>\n<div class=\"choice-container\">\n<button class=\"choice-btn\" data-scene='scene-get-higher'>Close file</button>\n</div>\n</div>\n"
+      "html": "<div class=\"case-file\">\n<h2 class=\"case-header\">&gt;&gt; LARKHILL LANE // CASE FILE C-42</h2>\n<p class=\"case-status\">&gt; STATUS: UNLISTED... NOT REAL... NOT ENTIRELY</p>\n<div class=\"case-tabs\">\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-main\">&gt; CASE FILE</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-persons\">&gt; PERSONS OF INTEREST</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-evidence\">&gt; EVIDENCE</button>\n</div>\n<div id=\"cf-main\" class=\"case-tab-content\">\n<p>&gt; <span class=\"case-query\">QUERY:</span> PROPERTY VERIFICATION – NORTHWEST SECTOR C-42</p>\n<p>&gt; <span class=\"case-response\">ERROR - NO SUCH LISTING. FILE DOES NOT EXIST.</span></p>\n<h3>&gt; INCOMING TRANSMISSION... SOURCE: GRANNY (REAL ONE?)</h3>\n<button class=\"choice-btn case-play-audio\">&gt; PLAY AUDIO FRAGMENT</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"Tell Joe the property isn't listed anymore. Because it's not... real anymore. Not entirely... [STATIC]... Larkhill Lane.\"</p>\n</div>\n<div id=\"cf-persons\" class=\"case-tab-content\" style=\"display:none\">\n<h3>&gt; SUBJECT: JOE</h3>\n<p>&gt; <strong>STATUS:</strong> NUMB... AWAKENING</p>\n<p>&gt; <strong>AFFILIATION:</strong> HOME OFFICE (CIVIL SERVANT)</p>\n<p>&gt; <strong>PROFILE:</strong> Stocky frame, buzzed hair. Carries the weary warmth of forced smiles. A circuit-etched tattoo suggests a history with systems, logical and otherwise. Currently drawn into a system that defies logic.</p>\n<h3>&gt; SUBJECT: NEWT</h3>\n<p>&gt; <strong>STATUS:</strong> GROGGY... RECEPTIVE</p>\n<p>&gt; <strong>AFFILIATION:</strong> INDEPENDENT (SOUNDCLOUD ARTIST)</p>\n<p>&gt; <strong>PROFILE:</strong> Long blonde hair, sharp grin. A sly mischief in his eyes. Wears a slim gold chain. First point of contact for the anomalous transmission. Seems uniquely tuned to the unfolding weirdness.</p>\n<p>&gt; ASSOCIATES: DOOBIE &amp; GOOBY - Feline entities. Seemingly aware of the situation's gravity.</p>\n</div>\n<div id=\"cf-evidence\" class=\"case-tab-content\" style=\"display:none\">\n<div class=\"case-vhs\"></div>\n<p>&gt; ARTIFACT: VHS-C42</p>\n<p>&gt; Unmarked cassette discovered in a secure government facility. No case number assigned.</p>\n<p>&gt; Contents are... anomalous. Displays events that defy linear time.</p>\n<p class=\"case-vhs-status\">&gt; Artifact is dormant. Hover to detect energy signature.</p>\n<img src=\"images/joeNewtTape3.jpg\" alt=\"Distorted tape still\" class=\"case-evidence-image\">\n<button class=\"choice-btn case-play-audio\">&gt; PLAY ADDITIONAL AUDIO</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"There's more... the tape shows a door that isn't there.\"</p>\n</div>\n<div class=\"choice-container\">\n<button class=\"choice-btn\" data-set-state='{\"reviewedCaseFile\":true}' data-scene='scene-get-higher'>Close file</button>\n</div>\n</div>\n\n"
     }
   ]
 };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.22] - 2025-06-30
+### Added
+- Initial party sequence and Episode 1 ending.
+- Case file close button now sets `reviewedCaseFile`.
+- Paranoia branch marks `trustBroken`.
+### Changed
+- Pre-party scene leads into the new party sequence.
+
 ## [0.0.0.21] - 2025-06-29
 ### Added
 - Game state now tracks `reviewedCaseFile`, `trustBroken`, and `visitedLarkhill` for future branching.

--- a/episodes/episode1.json
+++ b/episodes/episode1.json
@@ -19,7 +19,7 @@
     },
     {
       "id": "scene-watch-tape-high",
-      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> Through a haze of smoke, you press play. The tape becomes a portal. Not just showing reality\u2014creating it. You watch yourselves get high, watching yourselves get high... The timestamp reads 10 YEARS AGO. The cats start speaking in unison: 'The loop tastes like time.'\n                </div>\n\n                <img src=\"images/joeNewtTape3.jpg\" alt=\"Watching the tape\" class=\"scene-image\">\n                <div class=\"choice-container\">\n                    <p>The loop is delicious. Do you...</p>\n                    <button class=\"choice-btn\" data-scene='scene-embrace-loop'>Embrace the loop. Get even higher.</button>\n                    <button class=\"choice-btn\" data-scene='scene-hallucination-start'>Fight it. Try to make sense of it.</button>\n                </div>"
+      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> Through a haze of smoke, you press play. The tape becomes a portal. Not just showing reality—creating it. You watch yourselves get high, watching yourselves get high... The timestamp reads 10 YEARS AGO. The cats start speaking in unison: 'The loop tastes like time.'\n                </div>\n\n                <img src=\"images/joeNewtTape3.jpg\" alt=\"Watching the tape\" class=\"scene-image\">\n                <div class=\"choice-container\">\n                    <p>The loop is delicious. Do you...</p>\n                    <button class=\"choice-btn\" data-scene='scene-embrace-loop'>Embrace the loop. Get even higher.</button>\n                    <button class=\"choice-btn\" data-scene='scene-hallucination-start'>Fight it. Try to make sense of it.</button>\n                </div>"
     },
     {
       "id": "scene-higher-forget",
@@ -118,7 +118,7 @@
     },
     {
       "id": "scene-paranoia-path",
-      "html": "<div class=\"dialogue\">\n                    <span class=\"character newt\">NEWT:</span> How do I know you didn't plant it? This is your office!\n                </div>\n                <div class=\"dialogue\">\n                    <span class=\"character joe\">JOE:</span> My mess? You're the one getting spooky notes from your gran!\n                </div>\n                <div class=\"choice-container\">\n                    <p>The trust shatters. Newt storms out with the tape.</p>\n                    <button class=\"choice-btn\" data-scene='scene-tobecontinued'>TO BE CONTINUED...</button>\n                </div>"
+      "html": "<div class=\"dialogue\">\n                    <span class=\"character newt\">NEWT:</span> How do I know you didn't plant it? This is your office!\n                </div>\n                <div class=\"dialogue\">\n                    <span class=\"character joe\">JOE:</span> My mess? You're the one getting spooky notes from your gran!\n                </div>\n                <div class=\"choice-container\">\n                    <p>The trust shatters. Newt storms out with the tape.</p>\n                    <button class=\"choice-btn\" data-set-state='{\"trustBroken\":true}' data-scene='scene-tobecontinued'>TO BE CONTINUED...</button>\n                </div>"
     },
     {
       "id": "scene-destroy-tape",
@@ -154,11 +154,51 @@
     },
     {
       "id": "scene-pre-party",
-      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> Bass rumbles the walls. Friends chatter nervously. Somewhere outside, a siren wails like a warning.\n                </div>\n                <div class=\"choice-container\">\n                    <p>The party is about to begin.</p>\n                    <button class=\"choice-btn\" data-restart>End demo.</button>\n                </div>"
+      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> Bass rumbles the walls. Friends chatter nervously. Somewhere outside, a siren wails like a warning.\n                </div>\n                <div class=\"choice-container\">\n                    <p>The party is about to begin.</p>\n                    <button class=\"choice-btn\" data-scene='scene-party-begins'>Let the party begin</button>\n                </div>"
+    },
+    {
+      "id": "scene-party-begins",
+      "html": "<div class=\"dialogue\"><span class=\"character system\">SYSTEM:</span> The lights dim as the flat fills with friends. A scratched trance record spins, rattling the windows. The tape sits on the table like an idol.</div><div class=\"choice-container\"><p>What do you do?</p><button class=\"choice-btn\" data-scene='scene-show-tape'>Show everyone the tape</button><button class=\"choice-btn\" data-scene='scene-keep-hidden'>Keep it hidden for now</button></div>"
+    },
+    {
+      "id": "scene-show-tape",
+      "html": "<div class=\"dialogue\"><span class=\"character newt\">NEWT:</span> Yo, check this out!</div><div class=\"dialogue\"><span class=\"character system\">SYSTEM:</span> A hush falls over the room as the VCR whirs. Static leaks from the speakers.</div><div class=\"choice-container\"><button class=\"choice-btn\" data-scene='scene-visions'>Watch together</button></div>"
+    },
+    {
+      "id": "scene-keep-hidden",
+      "html": "<div class=\"dialogue\"><span class=\"character joe\">JOE:</span> Let's enjoy the night first.</div><div class=\"dialogue\"><span class=\"character system\">SYSTEM:</span> The tape vibrates angrily inside the drawer.</div><div class=\"choice-container\"><button class=\"choice-btn\" data-scene='scene-visions'>Rejoin the party</button></div>"
+    },
+    {
+      "id": "scene-visions",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> The music warps. Guests blur like smeared film. Gooby and Doobie stare at a door that shouldn't exist.</div><div class='choice-container'><p>The door beckons.</p><button class='choice-btn' data-scene='scene-enter-door'>Open it</button><button class='choice-btn' data-scene='scene-ignore-door'>Ignore it</button></div>"
+    },
+    {
+      "id": "scene-ignore-door",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> Each time you look away, the door creeps closer. Whispers about loops spread among the partygoers.</div><div class='choice-container'><button class='choice-btn' data-scene='scene-enter-door'>Open the door anyway</button></div>"
+    },
+    {
+      "id": "scene-enter-door",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> The handle is ice cold. Beyond lies a corridor lined with VHS tapes, humming softly.</div><div class='choice-container'><p>Cross the threshold?</p><button class='choice-btn' data-scene='scene-larkhill-field' data-set-state='{\"visitedLarkhill\":true}'>Step through</button></div>"
+    },
+    {
+      "id": "scene-larkhill-field",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> Night air hits you. You're standing on Larkhill Lane. In the grass, a camera blinks red.</div><div class='choice-container'><p>How will you end this?</p><button class='choice-btn' data-scene='scene-record-ending'>Record your own ending</button><button class='choice-btn' data-scene='scene-stop-tape'>Search for the STOP tape</button></div>"
+    },
+    {
+      "id": "scene-record-ending",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> You hit RECORD. The world shudders, then clears. Maybe this is freedom.</div><div class='choice-container'><button class='choice-btn' data-scene='scene-episode1-end'>Fade out</button></div>"
+    },
+    {
+      "id": "scene-stop-tape",
+      "html": "<div class='dialogue'><span class='character system'>SYSTEM:</span> You dig through the weeds and uncover a tape marked STOP. It hums with potential.</div><div class='choice-container'><button class='choice-btn' data-scene='scene-episode1-end'>Play it</button></div>"
+    },
+    {
+      "id": "scene-episode1-end",
+      "html": "<h2 style='color:#ff00ff;text-align:center;'>END OF EPISODE 1</h2><div class='dialogue' id='state-summary'></div><div class='choice-container'><button class='choice-btn' data-restart>Restart</button></div>"
     },
     {
       "id": "scene-case-file",
-      "html": "<div class=\"case-file\">\n<h2 class=\"case-header\">&gt;&gt; LARKHILL LANE // CASE FILE C-42</h2>\n<p class=\"case-status\">&gt; STATUS: UNLISTED... NOT REAL... NOT ENTIRELY</p>\n<div class=\"case-tabs\">\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-main\">&gt; CASE FILE</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-persons\">&gt; PERSONS OF INTEREST</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-evidence\">&gt; EVIDENCE</button>\n</div>\n<div id=\"cf-main\" class=\"case-tab-content\">\n<p>&gt; <span class=\"case-query\">QUERY:</span> PROPERTY VERIFICATION \u2013 NORTHWEST SECTOR C-42</p>\n<p>&gt; <span class=\"case-response\">ERROR - NO SUCH LISTING. FILE DOES NOT EXIST.</span></p>\n<h3>&gt; INCOMING TRANSMISSION... SOURCE: GRANNY (REAL ONE?)</h3>\n<button class=\"choice-btn case-play-audio\">&gt; PLAY AUDIO FRAGMENT</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"Tell Joe the property isn't listed anymore. Because it's not... real anymore. Not entirely... [STATIC]... Larkhill Lane.\"</p>\n</div>\n<div id=\"cf-persons\" class=\"case-tab-content\" style=\"display:none\">\n<h3>&gt; SUBJECT: JOE</h3>\n<p>&gt; <strong>STATUS:</strong> NUMB... AWAKENING</p>\n<p>&gt; <strong>AFFILIATION:</strong> HOME OFFICE (CIVIL SERVANT)</p>\n<p>&gt; <strong>PROFILE:</strong> Stocky frame, buzzed hair. Carries the weary warmth of forced smiles. A circuit-etched tattoo suggests a history with systems, logical and otherwise. Currently drawn into a system that defies logic.</p>\n<h3>&gt; SUBJECT: NEWT</h3>\n<p>&gt; <strong>STATUS:</strong> GROGGY... RECEPTIVE</p>\n<p>&gt; <strong>AFFILIATION:</strong> INDEPENDENT (SOUNDCLOUD ARTIST)</p>\n<p>&gt; <strong>PROFILE:</strong> Long blonde hair, sharp grin. A sly mischief in his eyes. Wears a slim gold chain. First point of contact for the anomalous transmission. Seems uniquely tuned to the unfolding weirdness.</p>\n<p>&gt; ASSOCIATES: DOOBIE &amp; GOOBY - Feline entities. Seemingly aware of the situation's gravity.</p>\n</div>\n<div id=\"cf-evidence\" class=\"case-tab-content\" style=\"display:none\">\n<div class=\"case-vhs\"></div>\n<p>&gt; ARTIFACT: VHS-C42</p>\n<p>&gt; Unmarked cassette discovered in a secure government facility. No case number assigned.</p>\n<p>&gt; Contents are... anomalous. Displays events that defy linear time.</p>\n<p class=\"case-vhs-status\">&gt; Artifact is dormant. Hover to detect energy signature.</p>\n<img src=\"images/joeNewtTape3.jpg\" alt=\"Distorted tape still\" class=\"case-evidence-image\">\n<button class=\"choice-btn case-play-audio\">&gt; PLAY ADDITIONAL AUDIO</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"There's more... the tape shows a door that isn't there.\"</p>\n</div>\n<div class=\"choice-container\">\n<button class=\"choice-btn\" data-scene='scene-get-higher'>Close file</button>\n</div>\n</div>\n"
+      "html": "<div class=\"case-file\">\n<h2 class=\"case-header\">&gt;&gt; LARKHILL LANE // CASE FILE C-42</h2>\n<p class=\"case-status\">&gt; STATUS: UNLISTED... NOT REAL... NOT ENTIRELY</p>\n<div class=\"case-tabs\">\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-main\">&gt; CASE FILE</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-persons\">&gt; PERSONS OF INTEREST</button>\n<button class=\"choice-btn case-tab-button\" data-target=\"#cf-evidence\">&gt; EVIDENCE</button>\n</div>\n<div id=\"cf-main\" class=\"case-tab-content\">\n<p>&gt; <span class=\"case-query\">QUERY:</span> PROPERTY VERIFICATION – NORTHWEST SECTOR C-42</p>\n<p>&gt; <span class=\"case-response\">ERROR - NO SUCH LISTING. FILE DOES NOT EXIST.</span></p>\n<h3>&gt; INCOMING TRANSMISSION... SOURCE: GRANNY (REAL ONE?)</h3>\n<button class=\"choice-btn case-play-audio\">&gt; PLAY AUDIO FRAGMENT</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"Tell Joe the property isn't listed anymore. Because it's not... real anymore. Not entirely... [STATIC]... Larkhill Lane.\"</p>\n</div>\n<div id=\"cf-persons\" class=\"case-tab-content\" style=\"display:none\">\n<h3>&gt; SUBJECT: JOE</h3>\n<p>&gt; <strong>STATUS:</strong> NUMB... AWAKENING</p>\n<p>&gt; <strong>AFFILIATION:</strong> HOME OFFICE (CIVIL SERVANT)</p>\n<p>&gt; <strong>PROFILE:</strong> Stocky frame, buzzed hair. Carries the weary warmth of forced smiles. A circuit-etched tattoo suggests a history with systems, logical and otherwise. Currently drawn into a system that defies logic.</p>\n<h3>&gt; SUBJECT: NEWT</h3>\n<p>&gt; <strong>STATUS:</strong> GROGGY... RECEPTIVE</p>\n<p>&gt; <strong>AFFILIATION:</strong> INDEPENDENT (SOUNDCLOUD ARTIST)</p>\n<p>&gt; <strong>PROFILE:</strong> Long blonde hair, sharp grin. A sly mischief in his eyes. Wears a slim gold chain. First point of contact for the anomalous transmission. Seems uniquely tuned to the unfolding weirdness.</p>\n<p>&gt; ASSOCIATES: DOOBIE &amp; GOOBY - Feline entities. Seemingly aware of the situation's gravity.</p>\n</div>\n<div id=\"cf-evidence\" class=\"case-tab-content\" style=\"display:none\">\n<div class=\"case-vhs\"></div>\n<p>&gt; ARTIFACT: VHS-C42</p>\n<p>&gt; Unmarked cassette discovered in a secure government facility. No case number assigned.</p>\n<p>&gt; Contents are... anomalous. Displays events that defy linear time.</p>\n<p class=\"case-vhs-status\">&gt; Artifact is dormant. Hover to detect energy signature.</p>\n<img src=\"images/joeNewtTape3.jpg\" alt=\"Distorted tape still\" class=\"case-evidence-image\">\n<button class=\"choice-btn case-play-audio\">&gt; PLAY ADDITIONAL AUDIO</button>\n<p class=\"case-audio-transcript\" style=\"display:none\">\"There's more... the tape shows a door that isn't there.\"</p>\n</div>\n<div class=\"choice-container\">\n<button class=\"choice-btn\" data-set-state='{\"reviewedCaseFile\":true}' data-scene='scene-get-higher'>Close file</button>\n</div>\n</div>\n\n"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend Episode 1 with party sequence and finale
- mark state when reading the case file or breaking trust
- updated build artifacts and changelog

## Testing
- `npm run build-episodes`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dcc603450832a9eb10a2a498df7e1