### PR TITLE
Add CI workflow for test and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Run linter
+        run: npm run lint

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.23] - 2025-07-01
+### Added
+- Continuous integration workflow to automatically run tests and lint on pull requests.
+
 ## [0.0.0.22] - 2025-06-30
 ### Added
 - Initial party scenes extending Episode 1.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `npm test` and `npm run lint` on PRs
- document the new workflow in `CHANGELOG.md`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685dd505f650832ab1659974735fb139