### PR TITLE
Enable CI on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: ["*"]
   pull_request:
     branches: ["*"]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.3] - 2025-07-01
+### Changed
+- CI workflow now runs on pushes in addition to pull requests.
+
 ## [1.0.2] - 2025-06-27
 ### Added
 - Linting step documented in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- run CI workflow on pushes as well as pull requests
- document the new push trigger

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ddfdcb344832aa8d5e681632afd28