### PR TITLE
Add episode preview CLI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.0.0.30] - 2025-06-27
+### Added
+- Command-line script `preview-episode` for visualizing scene flow.
 
 ## [0.0.0.29] - 2025-06-27
 ### Changed

--- a/docs/WRITING_GUIDE.md
+++ b/docs/WRITING_GUIDE.md
@@ -72,3 +72,13 @@ Finally, run the tests to catch syntax errors or missing scenes:
 ```
 npm test
 ```
+
+## Previewing Episode Flow
+
+To visualize how scenes connect, run:
+
+```
+npm run preview-episode -- episodes/episode1.json
+```
+
+Replace the path with your episode file. The command prints each scene and the IDs it links to. Add `--dot` to output Graphviz format for drawing a flow chart.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "embed": "node scripts/embedEpisodes.js",
     "build-episodes": "node scripts/embedEpisodes.js",
     "lint": "eslint -c .eslintrc.json .",
-    "start": "node server.js"
+    "start": "node server.js",
+    "preview-episode": "node scripts/previewEpisode.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/previewEpisode.js
+++ b/scripts/previewEpisode.js
@@ -1,0 +1,78 @@
+// Simple CLI to preview episode scene flow and validate structure
+const fs = require('fs');
+
+function usage() {
+  console.log('Usage: node scripts/previewEpisode.js <episode.json> [--dot]');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  usage();
+}
+const filePath = args[0];
+const outputDot = args.includes('--dot');
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+} catch (err) {
+  console.error('Failed to read or parse', filePath + ':', err.message);
+  process.exit(1);
+}
+
+if (!data || typeof data !== 'object' || !Array.isArray(data.scenes)) {
+  console.error('Invalid episode format');
+  process.exit(1);
+}
+
+const idSet = new Set();
+for (const scene of data.scenes) {
+  if (!scene.id) {
+    console.error('Scene missing id');
+    process.exit(1);
+  }
+  if (idSet.has(scene.id)) {
+    console.error('Duplicate scene id', scene.id);
+    process.exit(1);
+  }
+  idSet.add(scene.id);
+}
+
+if (!idSet.has(data.start)) {
+  console.error('Start scene', data.start, 'not found');
+  process.exit(1);
+}
+
+function extractLinks(html) {
+  const links = [];
+  const regex = /data-scene=['"]([^'"#]+)['"]/g;
+  let m;
+  while ((m = regex.exec(html))) {
+    links.push(m[1]);
+  }
+  return links;
+}
+
+if (outputDot) {
+  console.log('digraph episode {');
+  for (const scene of data.scenes) {
+    const links = extractLinks(scene.html || '');
+    for (const target of links) {
+      if (!idSet.has(target)) {
+        console.warn(`// ${scene.id} -> missing ${target}`);
+      }
+      console.log(`  "${scene.id}" -> "${target}";`);
+    }
+    if (links.length === 0) {
+      console.log(`  "${scene.id}";`);
+    }
+  }
+  console.log('}');
+  process.exit(0);
+}
+
+for (const scene of data.scenes) {
+  const links = extractLinks(scene.html || '');
+  const linkStr = links.length ? links.join(', ') : '(end)';
+  console.log(`${scene.id} -> ${linkStr}`);
+}


### PR DESCRIPTION
## Summary
- add `scripts/previewEpisode.js` to inspect episode links
- expose it as `npm run preview-episode`
- document how to preview scene flows in `WRITING_GUIDE.md`
- note the new tool in `CHANGELOG`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685de523e458832a954763b25a58379c