### PR TITLE
Enable cross-device save import/export

### DIFF
--- a/dist/sw.js
+++ b/dist/sw.js
@@ -62,7 +62,8 @@ self.addEventListener('fetch', event => {
         cache.put(event.request, response.clone());
       }
       return response;
-    } catch (err) {
+    // Ignore network errors when offline
+    } catch {
       return cached;
     }
   })());

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.0.0.32] - 2025-06-28
+### Added
+- Optional save export/import for cross-device progress.
 ## [0.0.0.31] - 2025-06-27
 ### Changed
 - UI logic split into a new `sceneNavigation` module for easier maintenance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 Episode 1 ultimately aims for about an hour of play time, but the project is still in its infancy—less than ten percent of the planned content exists so far.
 
-Episode 1 is playable and features sound effects and a scene history overlay. Progress is saved in your browser using local storage. Episode 2 is under construction.
+Episode 1 is playable and features sound effects and a scene history overlay. Progress is saved in your browser using local storage. You can export this data from the Dev Tools screen and import it on another device. Episode 2 is under construction.
 
 ## Writing Episodes
 

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
     <div id="dev-screen" class="screen">
          <h1 class="glitch-title">DEV TOOLS</h1>
         <button id="clear-save-btn" class="menu-btn" aria-label="Clear saved progress">Clear Saves</button>
+        <button id="export-save-btn" class="menu-btn" aria-label="Download save file">Export Saves</button>
+        <input type="file" id="import-save-input" accept="application/json" style="display:none">
+        <button id="import-save-btn" class="menu-btn" aria-label="Load save file">Import Saves</button>
         <button id="close-dev-btn" class="menu-btn" aria-label="Return to title">Back</button>
     </div>
 

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -182,6 +182,36 @@ function getProgress() {
     return progress;
 }
 
+/**
+ * Export current game state and progress for cross-device saves.
+ * @returns {{state: Object, progress: Object}}
+ */
+function exportSaveData() {
+    return {
+        state: { ...gameState },
+        progress: { ...progress }
+    };
+}
+
+/**
+ * Import previously exported save data.
+ * @param {{state:Object, progress:Object}} data
+ * @returns {void}
+ */
+function importSaveData(data) {
+    if (!data || typeof data !== 'object') {
+        return;
+    }
+    if (data.state && typeof data.state === 'object') {
+        gameState = { ...defaultState, ...data.state };
+        saveState();
+    }
+    if (data.progress && typeof data.progress === 'object') {
+        progress = { episode: null, scene: null, ...data.progress };
+        saveProgress();
+    }
+}
+
 export {
     loadState,
     saveState,
@@ -193,5 +223,7 @@ export {
     saveProgress,
     setProgress,
     clearProgress,
-    getProgress
+    getProgress,
+    exportSaveData,
+    importSaveData
 };

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -21,6 +21,9 @@ const continueBtn = document.getElementById('continue-btn');
 const devBtn = document.getElementById('dev-btn');
 const devScreen = document.getElementById('dev-screen');
 const clearSaveBtn = document.getElementById('clear-save-btn');
+const exportSaveBtn = document.getElementById('export-save-btn');
+const importSaveBtn = document.getElementById('import-save-btn');
+const importSaveInput = document.getElementById('import-save-input');
 const closeDevBtn = document.getElementById('close-dev-btn');
 const recordLight = document.querySelector('.record-light');
 const episodeButtons = document.querySelectorAll('.episode-btn');
@@ -193,6 +196,42 @@ function init() {
             StateModule.resetState();
             Navigation.updateContinueButton();
             alert('Save data cleared');
+        });
+    }
+
+    if (exportSaveBtn) {
+        exportSaveBtn.addEventListener('click', () => {
+            const data = StateModule.exportSaveData();
+            const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'echo-tape-save.json';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
+    }
+
+    if (importSaveBtn && importSaveInput) {
+        importSaveBtn.addEventListener('click', () => importSaveInput.click());
+        importSaveInput.addEventListener('change', () => {
+            const file = importSaveInput.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = () => {
+                try {
+                    const data = JSON.parse(reader.result);
+                    StateModule.importSaveData(data);
+                    Navigation.updateContinueButton();
+                    alert('Save data imported');
+                } catch (err) {
+                    alert('Invalid save file');
+                }
+            };
+            reader.readAsText(file);
+            importSaveInput.value = '';
         });
     }
 

--- a/test/check.js
+++ b/test/check.js
@@ -12,7 +12,7 @@ for (const file of requiredFiles) {
 }
 try {
   execSync('node --check src/script.mjs', { stdio: 'inherit' });
-} catch (err) {
+} catch {
   console.error('Syntax error in src/script.mjs');
   missing = true;
 }
@@ -25,8 +25,8 @@ for (const jsonFile of episodeJsons) {
   let jsonData;
   try {
     jsonData = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-  } catch (err) {
-    console.error(`Invalid JSON in ${jsonFile}: ${err.message}`);
+  } catch (_err) {
+    console.error(`Invalid JSON in ${jsonFile}: ${_err.message}`);
     missing = true;
     continue;
   }
@@ -75,8 +75,8 @@ for (const jsonFile of episodeJsons) {
     while ((m = setStateRegex.exec(html))) {
       try {
         JSON.parse(m[2]);
-      } catch (err) {
-        console.error(`${jsonFile} scene '${scene.id}' has invalid data-set-state: ${err.message}`);
+      } catch (_err) {
+        console.error(`${jsonFile} scene '${scene.id}' has invalid data-set-state: ${_err.message}`);
         missing = true;
       }
     }
@@ -84,8 +84,8 @@ for (const jsonFile of episodeJsons) {
     while ((m = showIfRegex.exec(html))) {
       try {
         JSON.parse(m[2]);
-      } catch (err) {
-        console.error(`${jsonFile} scene '${scene.id}' has invalid data-show-if: ${err.message}`);
+      } catch (_err) {
+        console.error(`${jsonFile} scene '${scene.id}' has invalid data-show-if: ${_err.message}`);
         missing = true;
       }
     }
@@ -101,7 +101,7 @@ for (const jsonFile of episodeJsons) {
     try {
       execSync(`node -c "${jsPath}"`, { stdio: 'inherit' });
       jsContent = fs.readFileSync(jsPath, 'utf8');
-    } catch (err) {
+    } catch {
       console.error(`Syntax error in ${jsPath}`);
       missing = true;
       continue;
@@ -119,8 +119,8 @@ for (const jsonFile of episodeJsons) {
     let jsObj;
     try {
       jsObj = JSON.parse(match[2]);
-    } catch (err) {
-      console.error(`Invalid JSON object in ${jsPath}: ${err.message}`);
+    } catch (_err) {
+      console.error(`Invalid JSON object in ${jsPath}: ${_err.message}`);
       missing = true;
       continue;
     }
@@ -172,24 +172,24 @@ try {
       missing = true;
     }
   }
-} catch (err) {
-  console.error('Unable to verify sw.js:', err.message);
+} catch (_err) {
+  console.error('Unable to verify sw.js:', _err.message);
   missing = true;
 }
 
 // Ensure embedEpisodes.js handles invalid JSON
 try {
   require('./embedScript.test.js');
-} catch (err) {
-  console.error(err);
+} catch (_err) {
+  console.error(_err);
   missing = true;
 }
 
 // Run additional runtime tests
 try {
   require('./runtime.test.js');
-} catch (err) {
-  console.error(err);
+} catch (_err) {
+  console.error(_err);
   missing = true;
 }
 if (missing) {

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -145,6 +145,13 @@ async function runTests() {
   });
 
   State.setProgress('1', 'start');
+  const exported = State.exportSaveData();
+  assert.deepStrictEqual(exported.progress, { episode: '1', scene: 'start' });
+  assert.strictEqual(exported.state.hasTape, true);
+  State.setState('hasTape', false);
+  State.clearProgress();
+  State.importSaveData(exported);
+  assert.strictEqual(State.getState('hasTape'), true);
   assert.deepStrictEqual(State.getProgress(), { episode: '1', scene: 'start' });
   State.clearProgress();
   assert.deepStrictEqual(State.getProgress(), { episode: null, scene: null });


### PR DESCRIPTION
## Summary
- let players export and import save data via Dev Tools screen
- expose `exportSaveData` and `importSaveData` in the state module
- update runtime tests for the new API
- document optional cross-device saves and note in changelog

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint -c .eslintrc.json .`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dea0f428c832abfc8046ab97b6e15