### PR TITLE
Add contributor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Welcome to **The Echo Tape**, an experimental interactive story built for the browser. The project is still in its infancy—Episode 1 contains less than ten percent of the planned content.
 
 Most documentation lives in [docs/README.md](docs/README.md). Head there for details on running the game, writing episodes and contributing.
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for workflow examples and contributor tips.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing Guide
+
+Thank you for helping improve **The Echo Tape**! This project uses Node.js 18 and simple npm scripts to manage content and run the local server.
+
+## Setup
+1. Install Node.js 18 or higher.
+2. Clone this repository and install dependencies:
+   ```bash
+   npm install
+   ```
+
+## Running the Local Server
+Serve the project through a small HTTP server so that the service worker and episode files load correctly:
+```bash
+npm start
+```
+This runs the bundled `server.js`. You can also use your own server, e.g. `npx http-server`.
+
+## Building Episodes
+After editing any JSON file in `episodes/`, generate the embedded JavaScript and update the service worker:
+```bash
+npm run build-episodes
+```
+Commit the updated `.js` files in `dist/episodes/` along with the changed `.json`.
+
+## Testing and Linting
+Run the tests and linter before pushing changes:
+```bash
+npm test
+npm run lint
+```
+The tests ensure required files exist and validate episode structure.
+
+## Previewing Episode Flow
+To quickly inspect a single episode file you can run:
+```bash
+npm run preview-episode episodes/myEpisode.json
+```
+Add `--dot` to output Graphviz format.
+
+Happy hacking!

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,10 @@ Image assets are stored in the `images` folder. Sound effects and music live in 
 The project uses simple incremental build numbers in the form
 `MAJOR.MODERATE.MINOR.HOTFIX`. Only the last digit increases for each
 release. See [VERSIONING.md](VERSIONING.md) for more details.
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow tips and example commands.
+
 
 ## License
 


### PR DESCRIPTION
## Summary
- add docs/CONTRIBUTING.md with setup and common commands
- reference contributor guide from main README and docs README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685dede71b30832abcf8048cddbd143f