### PR TITLE
Improve history overlay titles

### DIFF
--- a/src/sceneNavigation.mjs
+++ b/src/sceneNavigation.mjs
@@ -241,12 +241,30 @@ function handleBackBtn(returnToTitle) {
 }
 
 /**
+ * Get a short title for a scene based on its content.
+ * @param {string} id
+ * @returns {string}
+ */
+function getSceneTitle(id) {
+    const el = document.getElementById(id);
+    if (!el) return id;
+    const heading = el.querySelector('h2');
+    if (heading && heading.textContent.trim()) {
+        return heading.textContent.trim();
+    }
+    const text = (el.innerText || el.textContent || '').trim();
+    const firstLine = text.split('\n').map(l => l.trim()).find(l => l);
+    return firstLine || id;
+}
+
+/**
  * Display the navigation history overlay.
  * @returns {void}
  */
 function showHistory() {
     if (!historyOverlay) return;
-    historyList.textContent = sceneHistory.join(' \u2192 ');
+    const titles = sceneHistory.map(id => getSceneTitle(id));
+    historyList.textContent = titles.join(' \u2192 ');
     historyOverlay.classList.add('visible');
     historyOverlay.setAttribute('aria-hidden', 'false');
     if (closeHistoryBtn) closeHistoryBtn.focus();


### PR DESCRIPTION
## Summary
- display scene titles rather than IDs in the history overlay
- expand DOM helpers in `uiInteractions.test.js`
- add a test ensuring human-readable history titles

## Testing
- `npm test`
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_685f3d2fc8bc832ab5aebc81a86ebb06