### PR TITLE
Add loop awareness state tracking

### DIFF
--- a/dist/episodes/episode1.js
+++ b/dist/episodes/episode1.js
@@ -52,7 +52,7 @@ window.localEpisodes["episode1"] = {
     },
     {
       "id": "scene-burn-tape",
-      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> You grab the tape and a lighter. As the flame touches the plastic, the tape doesn't melt. It glows. The room fills with the smell of ozone and burnt sugar. The tape begins to speak, its voice a chorus of every conversation you've ever had. It knows everything.\n                </div>\n                 <div class=\"choice-container\">\n                    <p>You can't destroy it. You've only made it aware of you. This is a <span class=\"trippy-text\">DEAD END</span>.</p>\n                    <button class=\"choice-btn\" data-scene='scene-start'>Restart The Loop</button>\n                </div>",
+      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> You grab the tape and a lighter. As the flame touches the plastic, the tape doesn't melt. It glows. The room fills with the smell of ozone and burnt sugar. The tape begins to speak, its voice a chorus of every conversation you've ever had. It knows everything.\n                </div>\n                <div class=\"dialogue\" id=\"state-summary\"></div>\n                 <div class=\"choice-container\">\n                    <p>You can't destroy it. You've only made it aware of you. This is a <span class=\"trippy-text\">DEAD END</span>.</p>\n                    <button class=\"choice-btn\" data-scene='scene-start'>Restart The Loop</button>\n                </div>",
       "showIf": {
         "hasTape": true
       }

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -1,6 +1,6 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-const CACHE_NAME = 'echo-tape-1.0.1-988a6610';
+const CACHE_NAME = 'echo-tape-1.0.1-feb50e78';
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.40] - 2025-06-28
+### Added
+- Persistent keys `endingChoice` and `loopAwareLevel` with summary display.
+
 ## [0.0.0.39] - 2025-06-27
 ### Added
 - Conditional case file tabs unlocked via new state flags.

--- a/episodes/episode1.json
+++ b/episodes/episode1.json
@@ -51,7 +51,7 @@
     },
     {
       "id": "scene-burn-tape",
-      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> You grab the tape and a lighter. As the flame touches the plastic, the tape doesn't melt. It glows. The room fills with the smell of ozone and burnt sugar. The tape begins to speak, its voice a chorus of every conversation you've ever had. It knows everything.\n                </div>\n                 <div class=\"choice-container\">\n                    <p>You can't destroy it. You've only made it aware of you. This is a <span class=\"trippy-text\">DEAD END</span>.</p>\n                    <button class=\"choice-btn\" data-scene='scene-start'>Restart The Loop</button>\n                </div>",
+      "html": "<div class=\"dialogue\">\n                    <span class=\"character system\">SYSTEM:</span> You grab the tape and a lighter. As the flame touches the plastic, the tape doesn't melt. It glows. The room fills with the smell of ozone and burnt sugar. The tape begins to speak, its voice a chorus of every conversation you've ever had. It knows everything.\n                </div>\n                <div class=\"dialogue\" id=\"state-summary\"></div>\n                 <div class=\"choice-container\">\n                    <p>You can't destroy it. You've only made it aware of you. This is a <span class=\"trippy-text\">DEAD END</span>.</p>\n                    <button class=\"choice-btn\" data-scene='scene-start'>Restart The Loop</button>\n                </div>",
       "showIf": {
         "hasTape": true
       }

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -16,7 +16,9 @@ const defaultState = {
     musicMuted: false,
     sfxMuted: false,
     musicVolume: 1,
-    sfxVolume: 1
+    sfxVolume: 1,
+    endingChoice: null,
+    loopAwareLevel: 0
 };
 
 let gameState = { ...defaultState };
@@ -132,7 +134,9 @@ function updateStateSummary() {
         const caseFileText = gameState.reviewedCaseFile ? 'You studied the case file.' : 'You have yet to read the case file.';
         const trustText = gameState.trustBroken ? 'Distrust festers between you.' : 'Trust remains intact.';
         const laneText = gameState.visitedLarkhill ? 'Larkhill Lane has been explored.' : 'Larkhill Lane is still a mystery.';
-        summary.textContent = [awareText, itemText, caseFileText, trustText, laneText].join(' ');
+        const loopLevelText = `Loop awareness level: ${gameState.loopAwareLevel}`;
+        const endingText = gameState.endingChoice ? `Ending chosen: ${gameState.endingChoice}.` : 'No ending reached yet.';
+        summary.textContent = [awareText, itemText, caseFileText, trustText, laneText, loopLevelText, endingText].join(' ');
     }
 }
 

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -129,9 +129,15 @@ async function runTests() {
 
   // State module tests
   State.loadState();
+  assert.strictEqual(State.getState('loopAwareLevel'), 0);
+  assert.strictEqual(State.getState('endingChoice'), null);
   assert.strictEqual(State.getState('hasTape'), false);
   State.setState('hasTape', true);
+  State.setState('endingChoice', 'escape');
+  State.setState('loopAwareLevel', 2);
   assert.strictEqual(State.getState('hasTape'), true);
+  assert.strictEqual(State.getState('endingChoice'), 'escape');
+  assert.strictEqual(State.getState('loopAwareLevel'), 2);
   assert.deepStrictEqual(JSON.parse(storage.store.echoTapeState), {
     awareOfLoop: false,
     hasTape: true,
@@ -143,17 +149,21 @@ async function runTests() {
     musicMuted: false,
     sfxMuted: false,
     musicVolume: 1,
-    sfxVolume: 1
+    sfxVolume: 1,
+    endingChoice: 'escape',
+    loopAwareLevel: 2
   });
 
   State.setProgress('1', 'start');
   const exported = State.exportSaveData();
   assert.deepStrictEqual(exported.progress, { episode: '1', scene: 'start' });
   assert.strictEqual(exported.state.hasTape, true);
+  assert.strictEqual(exported.state.endingChoice, 'escape');
   State.setState('hasTape', false);
   State.clearProgress();
   State.importSaveData(exported);
   assert.strictEqual(State.getState('hasTape'), true);
+  assert.strictEqual(State.getState('endingChoice'), 'escape');
   assert.deepStrictEqual(State.getProgress(), { episode: '1', scene: 'start' });
   State.clearProgress();
   assert.deepStrictEqual(State.getProgress(), { episode: null, scene: null });


### PR DESCRIPTION
## Summary
- persist new `endingChoice` and `loopAwareLevel` values
- display them in the final state summary
- insert a new `state-summary` placeholder in a dead-end scene
- test the new state keys
- document update in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68606a71f21c832a9eb66dd8719c9b82