### PR TITLE
Improve offline episode message

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.42] - 2025-06-29
+### Added
+- Offline episode load message now reports connection status and last saved progress.
+- Episode loader automatically retries after a short delay.
+
 ## [0.0.0.41] - 2025-06-28
 ### Added
 - Voiceover volume slider with voice clips in Episode 1.

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -232,10 +232,12 @@ async function runTests() {
   assert.strictEqual(elements['back-btn'].textContent, 'Home');
 
   delete global.window.localEpisodes;
+  navigator.onLine = false;
   await Ui.loadEpisode('99');
   const errHtml = document.getElementById('vhs-screen').innerHTML;
   assert.ok(/Failed to load episode/i.test(errHtml));
   assert.ok(errHtml.includes('retry-load-btn'));
+  assert.ok(/You appear to be offline/i.test(errHtml));
 }
 
 runTests();


### PR DESCRIPTION
## Summary
- show network status and last save info when an episode fails to load
- automatically retry loading once
- test for offline status messaging
- document change in CHANGELOG

## Testing
- `npm test`
- `npm run lint` *(fails: A config object is using the "env" key)*

------
https://chatgpt.com/codex/tasks/task_e_6861c93fa620832abbf16322b64dee61