### PR TITLE
Improve audio context initialization logging

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.0.44] - 2025-06-30
+### Added
+- Error logging when the audio context fails to initialize or resume.
+
 ## [0.0.0.43] - 2025-06-30
 ### Added
 - State persistence now falls back to sessionStorage when localStorage is unavailable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-echo-tape",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "**The Echo Tape** is an experimental interactive story told entirely in the browser. Each episode unfolds like a choose‑your‑own‑adventure, letting you guide the characters through multiple paths. This was a story that me and my best friend came up with. To be used as both a learning tool and to tell a story.",
   "main": "src/script.mjs",
   "scripts": {

--- a/src/audio.mjs
+++ b/src/audio.mjs
@@ -29,11 +29,17 @@ let voiceVolume = 1;
  * @returns {void}
  */
 function initAudio() {
-    if (!audioCtx) {
-        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    }
-    if (audioCtx.state === 'suspended') {
-        audioCtx.resume().catch(() => {});
+    try {
+        if (!audioCtx) {
+            audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        if (audioCtx.state === 'suspended') {
+            audioCtx.resume().catch(err => {
+                console.error('Failed to resume audio context:', err);
+            });
+        }
+    } catch (err) {
+        console.error('Error initializing audio context:', err);
     }
 }
 


### PR DESCRIPTION
## Summary
- log failures when creating or resuming the `AudioContext`
- document the new behaviour in the changelog
- bump package version to 1.0.2

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861cd5fbcc0832a8ccf031bc34be553