### PR TITLE
Fix changelog version format

### DIFF
--- a/dist/sw.js
+++ b/dist/sw.js
@@ -1,6 +1,6 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-const CACHE_NAME = 'echo-tape-1.0.1-d243febd';
+const CACHE_NAME = 'echo-tape-1.0.2-4fe3acbe';
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {
@@ -29,6 +29,8 @@ self.addEventListener('install', event => {
       'audio/tape_fx.ogg',
       'audio/titleMusic.ogg',
       'audio/titleMusic2.ogg',
+      'audio/voice1.ogg',
+      'audio/voice2.ogg',
       'images/joeNewtTape.jpg',
       'images/joeNewtTape2.jpg',
       'images/joeNewtTape3.jpg',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,199 +2,199 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.0.44] - 2025-06-30
+## [0.0.44] - 2025-06-30
 ### Added
 - Error logging when the audio context fails to initialize or resume.
 
-## [0.0.0.43] - 2025-06-30
+## [0.0.43] - 2025-06-30
 ### Added
 - State persistence now falls back to sessionStorage when localStorage is unavailable.
 
-## [0.0.0.42] - 2025-06-29
+## [0.0.42] - 2025-06-29
 ### Added
 - Offline episode load message now reports connection status and last saved progress.
 - Episode loader automatically retries after a short delay.
 
-## [0.0.0.41] - 2025-06-28
+## [0.0.41] - 2025-06-28
 ### Added
 - Voiceover volume slider with voice clips in Episode 1.
 
-## [0.0.0.40] - 2025-06-28
+## [0.0.40] - 2025-06-28
 ### Added
 - Persistent keys `endingChoice` and `loopAwareLevel` with summary display.
 
-## [0.0.0.39] - 2025-06-27
+## [0.0.39] - 2025-06-27
 ### Added
 - Conditional case file tabs unlocked via new state flags.
 
-## [0.0.0.38] - 2025-06-27
+## [0.0.38] - 2025-06-27
 ### Fixed
 - Updated `sceneNavigation` to import the bundled DOMPurify directly so Node tests run without build tooling.
 - Converted ESLint configuration to `.cjs` format and updated the lint script for compatibility with Node 22.
 
-## [0.0.0.37] - 2025-06-27
+## [0.0.37] - 2025-06-27
 ### Added
 - Tests for keyboard navigation and case file behaviour.
 - Initial Episode 2 file with a few scenes.
 
-## [0.0.0.36] - 2025-06-27
+## [0.0.36] - 2025-06-27
 ### Changed
 - Updated `package.json` `main` field to reference `src/script.mjs`.
 
 
-## [0.0.0.35] - 2025-06-27
+## [0.0.35] - 2025-06-27
 ### Changed
 - Removed leftover hardcoded episode `<script>` tags from `index.html`. Episode scripts now load exclusively via `manifest.json`.
 
 
-## [0.0.0.34] - 2025-06-27
+## [0.0.34] - 2025-06-27
 ### Changed
 - Service worker cache name now includes a fingerprint of all assets for automatic invalidation.
 
-## [0.0.0.33] - 2025-06-27
+## [0.0.33] - 2025-06-27
 ### Added
 - Focus styles for interactive buttons.
 - ARIA roles and keyboard navigation for overlays.
 
-## [0.0.0.32] - 2025-06-27
+## [0.0.32] - 2025-06-27
 ### Added
 - Optional save export/import for cross-device progress.
 
-## [0.0.0.31] - 2025-06-27
+## [0.0.31] - 2025-06-27
 ### Changed
 - UI logic split into a new `sceneNavigation` module for easier maintenance.
 
-## [0.0.0.30] - 2025-06-27
+## [0.0.30] - 2025-06-27
 ### Added
 - Command-line script `preview-episode` for visualizing scene flow.
 
-## [0.0.0.29] - 2025-06-27
+## [0.0.29] - 2025-06-27
 ### Changed
 - CI workflow now runs on pushes in addition to pull requests.
 
-## 0.0.0.28] - 2025-06-37
+## [0.0.28] - 2025-06-27
 ### Added
 - JSDoc comments across core modules for improved type hints.
 
-## [0.0.0.27] - 2025-06-27
+## [0.0.27] - 2025-06-27
 ### Fixed
 - Static background sound now respects the SFX volume and mute settings.
 
-## [0.0.0.26] - 2025-06-27
+## [0.0.26] - 2025-06-27
 ### Added
 - Linting step documented in `AGENTS.md`.
 - CI workflow now explicitly runs tests and lint on pull requests.
 
-## [0.0.0.25] - 2025-06-27
+## [0.0.25] - 2025-06-27
 ### Changed
 - Development server now compresses responses and sets cache headers.
 
-## [0.0.0.24] - 2025-06-27
+## [0.0.24] - 2025-06-27
 ### Added
 - Top-level README linking to docs.
 
-## [0.0.0.23] - 2025-06-27
+## [0.0.23] - 2025-06-27
 ### Added
 - Continuous integration workflow to automatically run tests and lint on pull requests.
 
-## [0.0.0.22] - 2025-06-27
+## [0.0.22] - 2025-06-27
 ### Added
 - Initial party scenes extending Episode 1.
 
-## [0.0.0.21] - 2025-06-27
+## [0.0.21] - 2025-06-27
 ### Added
 - Game state now tracks `reviewedCaseFile`, `trustBroken`, and `visitedLarkhill` for future branching.
 
 
-## [0.0.0.20] - 2025-06-27
+## [0.0.20] - 2025-06-27
 ### Changed
 - Intro music loops during Episode 1 crawl.
 - Wider text area for the Episode 1 intro crawl.
 
-## [0.0.0.19] - 2025-06-27
+## [0.0.19] - 2025-06-27
 ### Added
 - Intro music for Episode 1 crawl using `introEP1.ogg`.
 - Support for images within Episode 1 scenes.
 ### Changed
 - Star Wars style crawl text now larger with fade effects.
 
-## [0.0.0.18] - 2025-06-26
+## [0.0.18] - 2025-06-26
 ### Added
 - Added case file module scene with tabbed interface and audio cues in Episode 1.
 
-## [0.0.0.17] - 2025-06-26
+## [0.0.17] - 2025-06-26
 ### Added
 - Star Wars style crawl intro for Episode 1 that fades into the logo.
 
-## [0.0.0.16] - 2025-06-26
+## [0.0.16] - 2025-06-26
 ### Added
 - Import map for DOMPurify so the game works on static hosts.
 - Warning when running over `file:` protocol.
 ### Fixed
 - Service worker caching now uses absolute URLs to avoid install failures.
 
-## [0.0.0.15] - 2025-06-26
+## [0.0.15] - 2025-06-26
 ### Added
 - `npm start` script that launches a simple static server.
 - README updated to recommend serving the game over HTTP.
 
-## [0.0.0.14] - 2025-06-26
+## [0.0.14] - 2025-06-26
 ### Added
 - In-game message with retry option when an episode fails to load.
 
-## [0.0.0.13] - 2025-06-26
+## [0.0.13] - 2025-06-26
 ### Added
 - Build script now outputs `dist/episodes/manifest.json` listing episodes.
 - UI loads episode scripts dynamically based on this manifest.
 - Removed hardcoded episode `<script>` tags from `index.html`.
 
-## [0.0.0.12] - 2025-06-26
+## [0.0.12] - 2025-06-26
 ### Changed
 - Converted core JavaScript files to ES modules and updated tests accordingly.
 
-## [0.0.0.11] - 2025-06-26
+## [0.0.11] - 2025-06-26
 ### Changed
 - Service worker now embeds the build number during `npm run build-episodes`.
 - `embedEpisodes.js` now reports parse errors with the file name and exits with a non-zero status.
 
-## [0.0.0.10] - 2025-06-26
+## [0.0.10] - 2025-06-26
 ### Added
 - Service worker cache is now generated automatically when running `npm run build-episodes`.
 - Test now validates JSON in `data-set-state` and `data-show-if` attributes.
 
-## [0.0.0.9] - 2025-06-26
+## [0.0.9] - 2025-06-26
 ### Changed
 - `initAudio` now resumes the audio context when suspended.
 
-## [0.0.0.8] - 2025-06-26
+## [0.0.8] - 2025-06-26
 ### Added
 - Utility function `playAudioElement` to handle volume-aware playback.
 - `playVhsSound`, `playSceneSound`, `playTitleMusic`, and `playTitleMusic2` now use the new helper.
 
-## [0.0.0.7] - 2025-06-26
+## [0.0.7] - 2025-06-26
 ### Added
 - `ACT1_DRAFT.md` containing the full first act script.
 - README link to the new draft.
 
-## [0.0.0.6] - 2025-06-26
+## [0.0.6] - 2025-06-26
 ### Added
 - Continued Episode 1 with new party setup scenes.
 - Local ESLint setup with a `lint` script for checking code style.
 - Added `SCRIPT_GUIDELINES.md` with a narrative script reference.
 
-## [0.0.0.5] - 2025-06-26
+## [0.0.5] - 2025-06-26
 ### Added
 - Branch point in Episode 1 allowing players to play, investigate, or destroy the tape.
 ### Changed
 - Updated README and writing guide with instructions on building episodes and running tests.
 
-## [0.0.0.4] - 2025-06-25
+## [0.0.4] - 2025-06-25
 ### Added
 - Centralized image assets in new `images/` folder.
 - "Home" button on the first scene of each episode now returns to the title screen.
 - Runtime tests for state persistence and audio controls.
 
-## [0.0.0.3] - 2025-06-25
+## [0.0.3] - 2025-06-25
 ### Added
 - Replaced inline `onclick` attributes in episode files with `data` attributes and event delegation.
 - Updated writing guide and tests accordingly.
@@ -212,7 +212,7 @@ All notable changes to this project will be documented in this file.
 - Switched to the 0.0.x versioning scheme and renumbered earlier drafts.
 - Contributor guide now notes running `npm run embed` after editing episodes.
 
-## [0.0.0.2] - 2025-06-25
+## [0.0.2] - 2025-06-25
 ### Added
 - Audio files now use .ogg format and .wav files removed.
 - Static audio stops when returning to menus.
@@ -235,7 +235,7 @@ All notable changes to this project will be documented in this file.
 - Noted early development status in README and AGENTS.
 - CHANGELOG now lists releases in reverse chronological order.
 
-## [0.0.0.1] - 2025-06-24
+## [0.0.1] - 2025-06-24
 ### Added
 - Initial code imported from offline development on June 26.
 - Save progress across sessions with a Continue option.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -4,7 +4,7 @@ The release number lives in the `version` field of `package.json` and follows a
 standard `MAJOR.MINOR.PATCH` format. The build script reads this value and
 embeds it into the service worker’s `CACHE_NAME`. Bumping the version forces
 users to fetch a new cache of the application.
-The 0.0.x numbering scheme began with release 0.0.0.3.
+The 0.0.x numbering scheme began with release 0.0.3.
 
 To publish a new version:
 


### PR DESCRIPTION
## Summary
- standardize version headings in `CHANGELOG.md` to `0.0.x`
- clarify the starting version in `VERSIONING.md`
- update generated files via tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861ce791290832aa0344c0fb7017083