### PR TITLE
Add optional auto backup via File System Access

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.45] - 2025-06-30
+### Added
+- Optional automatic save backups to a user-selected file.
+
 ## [0.0.44] - 2025-06-30
 ### Added
 - Error logging when the audio context fails to initialize or resume.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 Episode 1 ultimately aims for about an hour of play time, but the project is still in its infancy—less than ten percent of the planned content exists so far.
 
-Episode 1 is playable and features sound effects and a scene history overlay. Progress is saved in your browser using local or session storage. You can export this data from the Dev Tools screen and import it on another device. Episode 2 is under construction.
+Episode 1 is playable and features sound effects and a scene history overlay. Progress is saved in your browser using local or session storage. You can export this data from the Dev Tools screen and import it on another device. A new **Enable Sync** button lets you choose a file for automatic backups – store it in a synced folder to keep progress across devices. Episode 2 is under construction.
 
 ## Writing Episodes
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
          <h1 class="glitch-title">DEV TOOLS</h1>
         <button id="clear-save-btn" class="menu-btn" aria-label="Clear saved progress">Clear Saves</button>
         <button id="export-save-btn" class="menu-btn" aria-label="Download save file">Export Saves</button>
+        <button id="enable-backup-btn" class="menu-btn" aria-label="Enable automatic backup">Enable Sync</button>
         <input type="file" id="import-save-input" accept="application/json" style="display:none">
         <button id="import-save-btn" class="menu-btn" aria-label="Load save file">Import Saves</button>
         <button id="close-dev-btn" class="menu-btn" aria-label="Return to title">Back</button>

--- a/src/ui.mjs
+++ b/src/ui.mjs
@@ -22,6 +22,7 @@ const devBtn = document.getElementById('dev-btn');
 const devScreen = document.getElementById('dev-screen');
 const clearSaveBtn = document.getElementById('clear-save-btn');
 const exportSaveBtn = document.getElementById('export-save-btn');
+const enableBackupBtn = document.getElementById('enable-backup-btn');
 const importSaveBtn = document.getElementById('import-save-btn');
 const importSaveInput = document.getElementById('import-save-input');
 const closeDevBtn = document.getElementById('close-dev-btn');
@@ -223,6 +224,17 @@ function init() {
             a.click();
             document.body.removeChild(a);
             URL.revokeObjectURL(url);
+        });
+    }
+
+    if (enableBackupBtn) {
+        enableBackupBtn.addEventListener('click', async () => {
+            try {
+                await StateModule.chooseBackupFile();
+                alert('Automatic backup enabled');
+            } catch (err) {
+                alert('Auto backup not supported');
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- add `Enable Sync` button in the Dev Tools menu
- support auto-backup in `state` module with File System Access API
- hook up button to enable backups in UI
- document the new feature
- note change in changelog

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861d02b2628832a9f32fd297e04b9d4