### PR TITLE
Expand test suite for audio and service worker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.46] - 2025-07-01
+### Added
+- Tests for audio playback fallback and service worker caching.
+
 ## [0.0.45] - 2025-06-30
 ### Added
 - Optional automatic save backups to a user-selected file.

--- a/test/check.js
+++ b/test/check.js
@@ -198,6 +198,12 @@ try {
   console.error(_err);
   missing = true;
 }
+try {
+  require('./swCache.test.js');
+} catch (_err) {
+  console.error(_err);
+  missing = true;
+}
 if (missing) {
   console.error('Test failed');
   process.exit(1);

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -188,6 +188,18 @@ async function runTests() {
   assert.strictEqual(elements['sfx-static'].paused, true);
   assert.strictEqual(elements['sfx-static'].currentTime, 0);
 
+  // Audio play fallback when play() fails
+  let clickFallback = false;
+  document.addEventListener = (type, handler) => {
+    if (type === 'click') { clickFallback = true; handler(); }
+  };
+  const failEl = createAudioElement();
+  failEl.play = () => { failEl.playCalls++; return { catch(fn){ fn(new Error('x')); } }; };
+  Audio.playVoiceClip(failEl);
+  assert.ok(clickFallback);
+  assert.strictEqual(failEl.playCalls, 2);
+  document.addEventListener = () => {};
+
   // UI module tests
   const Ui = await import(pathToFileURL(path.join(__dirname, '../src/ui.mjs')));
 

--- a/test/swCache.test.js
+++ b/test/swCache.test.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+async function runTests() {
+  const swPath = path.join(__dirname, '..', 'dist', 'sw.js');
+  const code = fs.readFileSync(swPath, 'utf8');
+
+  const events = {};
+  const ctx = {
+    self: {
+      location: { origin: 'https://example.com' },
+      addEventListener(type, fn) { events[type] = fn; },
+      skipWaiting() {},
+      clients: { claim() {} }
+    },
+    caches: {
+      cached: 'cached-response',
+      async match() { return this.cached; },
+      async open() { return { put() {} }; },
+      async keys() { return []; }
+    },
+    fetch: null,
+    console
+  };
+  vm.createContext(ctx);
+  vm.runInContext(code, ctx);
+
+  assert.ok(typeof events.fetch === 'function');
+
+  // Successful network response should be returned and cached
+  let putCalled = false;
+  ctx.fetch = async () => ({ status: 200, type: 'basic', clone() { return this; } });
+  ctx.caches.open = async () => ({ put() { putCalled = true; } });
+  ctx.caches.match = async () => null;
+  let p;
+  events.fetch({ request: { method: 'GET' }, respondWith(pr) { p = pr; } });
+  const resp1 = await p;
+  assert.strictEqual(resp1.status, 200);
+  assert.ok(putCalled);
+
+  // Network failure should fall back to cached response
+  ctx.fetch = async () => { throw new Error('fail'); };
+  ctx.caches.match = async () => 'cached-response';
+  putCalled = false;
+  events.fetch({ request: { method: 'GET' }, respondWith(pr) { p = pr; } });
+  const resp2 = await p;
+  assert.strictEqual(resp2, 'cached-response');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- add coverage for audio playback fallback
- test service worker caching behavior
- integrate new tests into check.js
- record changes in `CHANGELOG.md`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861d496ff5c832a810b96871efa67ef