### PR TITLE
Add JSDoc linting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,8 @@ module.exports = {
     es2021: true,
     node: true
   },
-  extends: 'eslint:recommended',
+  extends: ['eslint:recommended', 'plugin:jsdoc/recommended'],
+  plugins: ['jsdoc'],
   parserOptions: {
     ecmaVersion: 12,
     sourceType: 'module'
@@ -16,6 +17,9 @@ module.exports = {
   },
   rules: {
     semi: ['error', 'always'],
-    'no-var': 'error'
+    'no-var': 'error',
+    'jsdoc/require-jsdoc': 'off',
+    'jsdoc/require-param-type': 'error',
+    'jsdoc/require-returns-type': 'error'
   }
 };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.47] - 2025-07-02
+### Added
+- ESLint JSDoc plugin with rules requiring parameter and return types.
+- Documentation comments for episode helpers.
+
 ## [0.0.46] - 2025-07-01
 ### Added
 - Tests for audio playback fallback and service worker caching.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "eslint": "8.57.1",
+    "eslint-plugin-jsdoc": "^51.2.3",
     "vite": "^7.0.0"
   },
   "dependencies": {

--- a/src/sceneNavigation.mjs
+++ b/src/sceneNavigation.mjs
@@ -30,14 +30,28 @@ let firstSceneId = null;
 let loadRetryTimer = null;
 let loadRetryAttempted = false;
 
+/**
+ * Store the active episode number.
+ * @param {string} ep - Episode identifier.
+ * @returns {void}
+ */
 function setCurrentEpisode(ep) {
     currentEpisode = ep;
 }
 
+/**
+ * Remember the first scene ID for back button logic.
+ * @param {string} id - Scene element ID.
+ * @returns {void}
+ */
 function setFirstSceneId(id) {
     firstSceneId = id;
 }
 
+/**
+ * Clear stored scene history.
+ * @returns {void}
+ */
 function clearHistory() {
     sceneHistory = [];
 }


### PR DESCRIPTION
## Summary
- add eslint-plugin-jsdoc and enable parameter/return type rules
- document scene navigation helpers
- update changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861d6ab45b0832a83a38d505fe5337a