### PR TITLE
Improve save sync

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.48] - 2025-07-03
+### Added
+- Sync file selection now imports existing save data for seamless cross-device play.
+
 ## [0.0.47] - 2025-07-02
 ### Added
 - ESLint JSDoc plugin with rules requiring parameter and return types.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 Episode 1 ultimately aims for about an hour of play time, but the project is still in its infancy—less than ten percent of the planned content exists so far.
 
-Episode 1 is playable and features sound effects and a scene history overlay. Progress is saved in your browser using local or session storage. You can export this data from the Dev Tools screen and import it on another device. A new **Enable Sync** button lets you choose a file for automatic backups – store it in a synced folder to keep progress across devices. Episode 2 is under construction.
+Episode 1 is playable and features sound effects and a scene history overlay. Progress is saved in your browser using local or session storage. You can export this data from the Dev Tools screen and import it on another device. A new **Enable Sync** button lets you choose a file for automatic backups. If the file already contains a save, it's loaded immediately – store it in a synced folder to keep progress across devices. Episode 2 is under construction.
 
 ## Writing Episodes
 

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -202,6 +202,20 @@ async function chooseBackupFile() {
         suggestedName: 'echo-tape-save.json',
         types: [{ description: 'JSON', accept: { 'application/json': ['.json'] } }]
     });
+    try {
+        const file = await backupHandle.getFile();
+        if (file.size > 0) {
+            const text = await file.text();
+            try {
+                const data = JSON.parse(text);
+                importSaveData(data);
+            } catch (err) {
+                console.error('Invalid backup file', err);
+            }
+        }
+    } catch (err) {
+        console.error('Failed to read backup file', err);
+    }
     await backupToFile();
 }
 


### PR DESCRIPTION
## Summary
- load existing save data when selecting a sync file
- document the new behaviour in README
- note the change in the changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861db61efb4832a9d93aae63af553a7