### PR TITLE
Add episode builder CLI and dynamic episode list

### DIFF
--- a/dist/episodes/episode0.js
+++ b/dist/episodes/episode0.js
@@ -1,5 +1,6 @@
 window.localEpisodes = window.localEpisodes || {};
 window.localEpisodes["episode0"] = {
+  "title": "Tutorial: Rocket League Warmup",
   "start": "scene-start",
   "scenes": [
     {

--- a/dist/episodes/episode1.js
+++ b/dist/episodes/episode1.js
@@ -1,5 +1,6 @@
 window.localEpisodes = window.localEpisodes || {};
 window.localEpisodes["episode1"] = {
+  "title": "Episode 1: The Tape & The Lane",
   "start": "scene-start",
   "scenes": [
     {

--- a/dist/episodes/episode2.js
+++ b/dist/episodes/episode2.js
@@ -1,5 +1,6 @@
 window.localEpisodes = window.localEpisodes || {};
 window.localEpisodes["episode2"] = {
+  "title": "Episode 2 - Coming Soon",
   "start": "scene-doorway",
   "scenes": [
     {

--- a/dist/episodes/manifest.json
+++ b/dist/episodes/manifest.json
@@ -1,5 +1,14 @@
 [
-  "episode0",
-  "episode1",
-  "episode2"
+  {
+    "id": "episode0",
+    "title": "Tutorial: Rocket League Warmup"
+  },
+  {
+    "id": "episode1",
+    "title": "Episode 1: The Tape & The Lane"
+  },
+  {
+    "id": "episode2",
+    "title": "Episode 2 - Coming Soon"
+  }
 ]

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -1,6 +1,6 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-const CACHE_NAME = 'echo-tape-1.0.2-4fe3acbe';
+const CACHE_NAME = 'echo-tape-1.0.2-62aed1f8';
 
 self.addEventListener('install', event => {
   event.waitUntil((async () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Quick Start section in `README.md` summarising setup and test steps.
 
+## [0.0.50] - 2025-07-05
+### Added
+- `episode-builder` CLI for interactively creating episode JSON files.
+### Changed
+- Episodes now include a `title` property and the game loads episode titles from a generated manifest.
+
 ## [0.0.48] - 2025-07-03
 ### Added
 - Sync file selection now imports existing save data for seamless cross-device play.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Episode 1 is playable and features sound effects and a scene history overlay. P
 
 ## Writing Episodes
 
-All episode data resides in the `episodes` folder. Each file is a JSON document describing a list of scenes. Writers can follow the structure documented in [WRITING_GUIDE.md](WRITING_GUIDE.md) to create new episodes. After editing a `.json` file, run `npm run build-episodes` to regenerate the embedded `.js`, update `sw.js` with the correct cache list, and commit both files.
+All episode data resides in the `episodes` folder. Each file is a JSON document describing a list of scenes. Writers can follow the structure documented in [WRITING_GUIDE.md](WRITING_GUIDE.md) to create new episodes. A simple CLI lives in `episode-builder/` for interactively generating these JSON files. After editing a `.json` file, run `npm run build-episodes` to regenerate the embedded `.js`, update `sw.js` with the correct cache list, and commit both files.
 For a broader sense of tone and structure, see [SCRIPT_GUIDELINES.md](SCRIPT_GUIDELINES.md), which contains an example script and style notes. A full draft of Act&nbsp;1 lives in [ACT1_DRAFT.md](ACT1_DRAFT.md).
 Image assets are stored in the `images` folder. Sound effects and music live in the `audio` folder.
 

--- a/episode-builder/README.md
+++ b/episode-builder/README.md
@@ -1,0 +1,5 @@
+# Episode Builder
+
+This standalone Node.js utility helps authors create new episode JSON files.
+Run `npm start` inside this folder and follow the prompts. The tool writes the
+resulting file to `../episodes/` so it can be loaded by the game.

--- a/episode-builder/builder.js
+++ b/episode-builder/builder.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+function ask(question) {
+  return new Promise(resolve => rl.question(question, answer => resolve(answer.trim())));
+}
+
+(async () => {
+  const id = await ask('Episode ID (e.g. episode3): ');
+  const title = await ask('Episode title: ');
+  const scenes = [];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const sceneId = await ask('Scene ID (leave blank to finish): ');
+    if (!sceneId) break;
+    const html = await ask('Scene HTML: ');
+    scenes.push({ id: sceneId, html });
+  }
+  let start = await ask('ID of the starting scene: ');
+  if (!start && scenes[0]) start = scenes[0].id;
+  if (!scenes.find(s => s.id === start) && scenes[0]) start = scenes[0].id;
+
+  const episode = { title, start, scenes };
+  const outPath = path.join(__dirname, '..', 'episodes', `${id}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(episode, null, 2));
+  console.log('Episode written to', outPath);
+  rl.close();
+})();

--- a/episode-builder/package.json
+++ b/episode-builder/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "episode-builder",
+  "version": "1.0.0",
+  "main": "builder.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node builder.js"
+  }
+}

--- a/episodes/episode0.json
+++ b/episodes/episode0.json
@@ -1,4 +1,5 @@
 {
+  "title": "Tutorial: Rocket League Warmup",
   "start": "scene-start",
   "scenes": [
     {

--- a/episodes/episode1.json
+++ b/episodes/episode1.json
@@ -1,4 +1,5 @@
 {
+  "title": "Episode 1: The Tape & The Lane",
   "start": "scene-start",
   "scenes": [
     {

--- a/episodes/episode2.json
+++ b/episodes/episode2.json
@@ -1,4 +1,5 @@
 {
+  "title": "Episode 2 - Coming Soon",
   "start": "scene-doorway",
   "scenes": [
     {

--- a/index.html
+++ b/index.html
@@ -30,9 +30,7 @@
 
     <div id="episode-screen" class="screen">
          <h1 class="glitch-title">SELECT EPISODE</h1>
-        <button class="episode-btn" data-episode="0" aria-label="Play Tutorial">Tutorial: Rocket League Warmup</button>
-         <button class="episode-btn" data-episode="1" aria-label="Play Episode 1">Episode 1: The Tape & The Lane</button>
-        <button class="episode-btn" disabled aria-label="Episode 2 coming soon">Episode 2 - Coming Soon</button>
+        <div id="episode-list"></div>
         <button id="return-title-btn" class="menu-btn" aria-label="Return to title">Back to Title</button>
     </div>
 

--- a/scripts/embedEpisodes.js
+++ b/scripts/embedEpisodes.js
@@ -7,6 +7,7 @@ const audioDir = path.join(__dirname, '..', 'audio');
 const imagesDir = path.join(__dirname, '..', 'images');
 
 const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.json'));
+const manifest = [];
 
 files.forEach(file => {
   const jsonPath = path.join(episodesDir, file);
@@ -25,10 +26,12 @@ files.forEach(file => {
     `\nwindow.localEpisodes[${JSON.stringify(name)}] = ` +
     JSON.stringify(jsonData, null, 2) + ';\n';
   fs.writeFileSync(jsPath, jsContent);
+
+  manifest.push({ id: name, title: jsonData.title || name });
 });
 
 // Write episode manifest for dynamic loading
-const manifest = files.map(f => path.basename(f, '.json')).sort();
+manifest.sort((a, b) => a.id.localeCompare(b.id));
 const manifestPath = path.join(__dirname, '..', 'dist', 'episodes', 'manifest.json');
 fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 console.log('Wrote manifest with', manifest.length, 'episodes');

--- a/src/sceneNavigation.mjs
+++ b/src/sceneNavigation.mjs
@@ -96,15 +96,16 @@ async function loadEpisode(ep, resumeScene) {
         loadRetryTimer = null;
     }
     let data;
+    const fileName = ep.startsWith('episode') ? ep : `episode${ep}`;
     try {
-        const resp = await fetch(`episodes/episode${ep}.json`);
+        const resp = await fetch(`episodes/${fileName}.json`);
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         data = await resp.json();
         loadRetryAttempted = false;
     } catch (err) {
         console.warn('Fetch failed, trying embedded episode data', err);
-        if (window.localEpisodes && window.localEpisodes[`episode${ep}`]) {
-            data = window.localEpisodes[`episode${ep}`];
+        if (window.localEpisodes && (window.localEpisodes[fileName] || window.localEpisodes[`episode${ep}`])) {
+            data = window.localEpisodes[fileName] || window.localEpisodes[`episode${ep}`];
         } else {
             console.error('Episode data not found');
             const onlineStatus = typeof navigator !== 'undefined'


### PR DESCRIPTION
## Summary
- add `episode-builder` tool for creating episode JSON
- store titles in episode data and manifest
- dynamically build episode selection list from manifest
- support both new and legacy episode names when loading

## Testing
- `npm run build-episodes`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686269363eac832a8f59604dc35a0f88