### PR TITLE
Improve persistent state handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.53] - 2025-07-06
+### Fixed
+- Graceful fallback when save data is corrupted or missing.
+- Import/export now validates data shape and backups continue reliably.
+
 ## [0.0.49] - 2025-07-04
 ### Added
 - Quick Start section in `README.md` summarising setup and test steps.

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -169,6 +169,17 @@ async function runTests() {
   State.clearProgress();
   assert.deepStrictEqual(State.getProgress(), { episode: null, scene: null });
 
+  // Corrupted save data handling
+  storage.store.echoTapeState = '{"hasTape":true';
+  State.loadState();
+  assert.strictEqual(State.getState('hasTape'), false);
+  storage.store.echoTapeState = '{"hasTape":"yes"}';
+  State.loadState();
+  assert.strictEqual(State.getState('hasTape'), false);
+  storage.store.echoTapeProgress = '{"episode":1}';
+  State.loadProgress();
+  assert.deepStrictEqual(State.getProgress(), { episode: null, scene: null });
+
   // Audio module tests
   Audio.setMusicVolume(0.5);
   assert.strictEqual(elements['title-music'].volume, 0.5);


### PR DESCRIPTION
## Summary
- sanitize save data when loading from storage or importing
- recover from corrupted save and progress objects
- add regression tests
- document changes in CHANGELOG

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864f93bbe58832a8bb5c76493e27cb1