### PR TITLE
Document episode JSON schema

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Service worker now uses separate runtime and static caches with version-based cleanup for smoother offline updates.
 
+## [0.0.55] - 2025-07-08
+### Added
+- `docs/EPISODE_SCHEMA.md` documenting the episode JSON structure.
+- Updated `WRITING_GUIDE.md` and main README to reference the schema and include the `title` field.
+
 ## [0.0.49] - 2025-07-04
 ### Added
 - Quick Start section in `README.md` summarising setup and test steps.

--- a/docs/EPISODE_SCHEMA.md
+++ b/docs/EPISODE_SCHEMA.md
@@ -1,0 +1,28 @@
+# Episode JSON Schema
+
+Every file in the `episodes/` directory describes a single episode. The format is intentionally simple so writers can work without JavaScript knowledge. Each episode JSON must include the following fields:
+
+```json
+{
+  "title": "Episode Name",
+  "start": "scene-id",
+  "scenes": [
+    {
+      "id": "scene-id",
+      "html": "<p>Scene HTML</p>",
+      "showIf": { "flag": true } // optional
+    }
+  ]
+}
+```
+
+## Field reference
+
+- **title** – Human readable name shown in the episode menu.
+- **start** – The ID of the first scene to display when the episode begins.
+- **scenes** – Array of scene objects. Each scene must contain:
+  - **id** – Unique identifier for the scene.
+  - **html** – Inner HTML that defines the text and choices.
+  - **showIf** – Optional object of state keys and expected values. The scene only appears when all conditions match.
+
+Buttons in the HTML use the attribute `data-scene="next-id"` to link to another scene. The build and test scripts verify that every referenced scene exists.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Episode 1 is playable and features sound effects and a scene history overlay. P
 
 ## Writing Episodes
 
-All episode data resides in the `episodes` folder. Each file is a JSON document describing a list of scenes. Writers can follow the structure documented in [WRITING_GUIDE.md](WRITING_GUIDE.md) to create new episodes. A simple CLI lives in `episode-builder/` for interactively generating these JSON files. After editing a `.json` file, run `npm run build-episodes` to regenerate the embedded `.js`, update `sw.js` with the correct cache list, and commit both files.
+All episode data resides in the `episodes` folder. Each file is a JSON document describing a list of scenes. Writers can follow the structure documented in [WRITING_GUIDE.md](WRITING_GUIDE.md) and [EPISODE_SCHEMA.md](EPISODE_SCHEMA.md) to create new episodes. A simple CLI lives in `episode-builder/` for interactively generating these JSON files. After editing a `.json` file, run `npm run build-episodes` to regenerate the embedded `.js`, update `sw.js` with the correct cache list, and commit both files.
 For a broader sense of tone and structure, see [SCRIPT_GUIDELINES.md](SCRIPT_GUIDELINES.md), which contains an example script and style notes. A full draft of Act&nbsp;1 lives in [ACT1_DRAFT.md](ACT1_DRAFT.md).
 Image assets are stored in the `images` folder. Sound effects and music live in the `audio` folder.
 

--- a/docs/WRITING_GUIDE.md
+++ b/docs/WRITING_GUIDE.md
@@ -9,11 +9,12 @@ and buttons the player will see.
 
 ```json
 {
-  "start": "scene-start",         // ID of the first scene to display
+  "title": "Episode Name",        // shown in the episode menu
+  "start": "scene-start",        // ID of the first scene to display
   "scenes": [
     {
-      "id": "scene-start",        // unique ID for the scene
-      "html": "<p>Your HTML here</p>"   // inner HTML for the scene
+      "id": "scene-start",       // unique ID for the scene
+      "html": "<p>Your HTML here</p>"  // inner HTML for the scene
     },
     {
       "id": "scene-next",
@@ -23,14 +24,18 @@ and buttons the player will see.
 }
 ```
 
+* **title** – the text displayed in the episode selection screen.
 * **start** – the ID of the first scene to show when the episode begins.
 * **scenes** – a list of scene objects. Each scene contains:
   * **id** – a unique name for the scene. Use short, descriptive words (e.g. `alley-start`).
   * **html** – the text and choices written in simple HTML. Use paragraphs
-    (`<p>`), headings (`<h2>`), and buttons. A button should call
-    `goToScene('target-id')` when clicked.
+    (`<p>`), headings (`<h2>`), and buttons. Buttons use `data-scene="next-id"`
+    to link to another scene.
   * **showIf** – optional state conditions. If provided, the scene only appears
     when every key/value pair matches the current game state.
+
+See [EPISODE_SCHEMA.md](EPISODE_SCHEMA.md) for a complete description of the
+required fields.
 
 ## Tips for Writing
 


### PR DESCRIPTION
## Summary
- document the required episode JSON structure in `EPISODE_SCHEMA.md`
- update the writing guide with the `title` field and schema link
- reference schema from docs/README
- log the documentation addition in CHANGELOG

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864fc6e68bc832a92c54d2c3b046fef