### PR TITLE
Improve build script reliability

### DIFF
--- a/dist/sw.js
+++ b/dist/sw.js
@@ -1,6 +1,6 @@
 // Service worker for The Echo Tape
 const CACHE_PREFIX = 'echo-tape-';
-const CACHE_NAME = 'echo-tape-1.0.2-2b3a2205';
+const CACHE_NAME = 'echo-tape-1.0.2-e4c033e7';
 const RUNTIME_CACHE = `${CACHE_NAME}-runtime`;
 
 const ASSETS = [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.56] - 2025-07-02
+### Fixed
+- `npm run build-episodes` now creates the `dist/episodes` folder if missing and
+  removes stale generated files. Fresh clones can build episodes without manual
+  setup.
+
 ## [0.0.53] - 2025-07-06
 ### Fixed
 - Graceful fallback when save data is corrupted or missing.


### PR DESCRIPTION
## Summary
- create `dist/episodes` automatically in `embedEpisodes.js`
- clean up stale generated episode files
- document the fix in `CHANGELOG`
- update generated manifest and service worker

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864ff248d08832abb757de2e5b87d0a